### PR TITLE
datalist を使って ComboBox を実装する

### DIFF
--- a/packages/core/src/components/inputs/ComboBox/index.story.tsx
+++ b/packages/core/src/components/inputs/ComboBox/index.story.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { ComboBox } from '.';
+
+type Option = {
+  label: string;
+  value: string;
+};
+
+export const Story = () => {
+  const options: Option[] = [
+    {
+      label: 'Apple',
+      value: 'りんご',
+    },
+    {
+      label: 'Banana',
+      value: 'バナナ',
+    },
+    {
+      label: 'Orange',
+      value: 'みかん',
+    },
+  ];
+
+  const [state1, setState1] = useState<Option | null>(options[0]);
+
+  const handleChange1 = (item: typeof options[number] | null) => {
+    setState1(item);
+  };
+
+  return (
+    <>
+      <h2>Basic</h2>
+      <ComboBox
+        options={options}
+        value={state1 ? state1.value : null}
+        onChange={handleChange1}
+        icon="list"
+        placeholder="くだもの"
+      />
+      <pre>
+        <code>{JSON.stringify(state1, null, 2)}</code>
+      </pre>
+
+      <h2>Disabled</h2>
+      <ComboBox options={options} value={state1 ? state1.value : null} onChange={handleChange1} icon="list" disabled />
+    </>
+  );
+};

--- a/packages/core/src/components/inputs/ComboBox/index.tsx
+++ b/packages/core/src/components/inputs/ComboBox/index.tsx
@@ -1,0 +1,136 @@
+import { css } from '@emotion/css';
+import type { IconName } from '@learn-react/icon';
+import type { ChangeEvent } from 'react';
+import { useMemo, useState } from 'react';
+import { Duration, FontSize, IconSize, LineHeight } from '../../../constants/Style';
+import { makeId } from '../../../helpers/String';
+import { cssVar, gutter, square } from '../../../helpers/Style';
+import { Icon } from '../../dataDisplay/Icon';
+
+type Option<T> = {
+  label: string;
+  value: T;
+  disabled?: boolean;
+};
+
+type Props<T> = {
+  value: T | null;
+  options: Option<T>[];
+  onChange: (item: Option<T> | null) => void;
+  id?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  /** 先頭に表示するアイコン */
+  icon?: IconName;
+};
+
+export const ComboBox = <T extends string | number>({
+  value,
+  options,
+  onChange,
+  id,
+  placeholder,
+  disabled,
+  icon,
+}: Props<T>) => {
+  const listId = useMemo(() => `datalist${makeId()}`, []);
+
+  const [inputValue, setInputValue] = useState(options.find(option => option.value === value)?.label);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+
+    if (e.target.value === '') {
+      onChange(null);
+      return;
+    }
+
+    const selectedItem = options.find(({ label }) => label === e.target.value);
+
+    selectedItem && onChange(selectedItem);
+  };
+
+  return (
+    <div className={styleBase} aria-disabled={disabled}>
+      {icon ? (
+        <span className={styleIcon}>
+          <Icon name={icon} />
+        </span>
+      ) : null}
+      <input
+        id={id}
+        className={styleInput}
+        list={listId}
+        value={inputValue}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={handleChange}
+      />
+      <datalist id={listId}>
+        {options.map(({ value, label, disabled }) => (
+          <option key={value} disabled={disabled}>
+            {label}
+          </option>
+        ))}
+      </datalist>
+    </div>
+  );
+};
+
+const styleBase = css`
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  box-shadow: none;
+  transition: box-shadow ${Duration.Fade};
+
+  &:after {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    height: 1px;
+    content: '';
+    background-color: ${cssVar('ThemePrimaryDark')};
+  }
+
+  > * {
+    min-width: 0;
+  }
+
+  > :not(:first-child) {
+    margin-left: ${gutter(2)};
+  }
+
+  &[aria-disabled='true'] {
+    background-color: ${cssVar('ThemeDisabledLight')};
+  }
+
+  &:focus-within {
+    box-shadow: inset 0 -2px 0 0 ${cssVar('ThemePrimaryDark')};
+  }
+`;
+
+const styleIcon = css`
+  flex: 0 0 auto;
+  ${square(IconSize.Large)}
+
+  > svg {
+    fill: ${cssVar('ThemePrimaryNeutral')};
+  }
+`;
+
+const styleInput = css`
+  display: inline-flex;
+  flex: 1 1 100%;
+  padding: ${gutter(2)} ${gutter(2)} ${gutter(2)} 0;
+  font-size: ${FontSize.Regular};
+  line-height: ${LineHeight.Regular};
+  color: ${cssVar('TextNeutral')};
+  background-color: transparent;
+  border: none;
+  outline: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+`;


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

- 選択肢数が膨大な `Select` コンポーネントだと手軽に絞り込めるような UI が欲しくなる。
- HTML 標準の `datalist` を使えばそれが簡単に実現できる。

### 何を変更したのか

`<input />` + `<datalist />` をラップした `ComboBox` コンポーネントを実装した。

https://twitter.com/wakamsha/status/1467518185515941888?s=20

### 備考

作ったはいいものの下記にある課題があるためそこまで出来が良いとは言い難い。

- `optgroup` のように選択肢をグルーピングできない
- ドロップダウンリストの意匠をカスタマイズできない
- ドロップダウンリストに表示できる項目が一行テキストのみ
  - `img` や 複数行テキスト等に対応できない

よって、より高機能な DataList コンポーネントの実装が求められる。

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
