### PR TITLE
PR 作成者を自動的に assignee に設定する GHA を定義する

### DIFF
--- a/.github/workflows/auto_author_assign.yml
+++ b/.github/workflows/auto_author_assign.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: toshimaru/auto-author-assign@v1.3.0
         with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

PR 作成者である自分を Assignee に設定する手間を軽減するため。

当プロジェクトでは PR 作成者は `Assignees` に自身を設定する運用が敷かれている。フローに一貫性があるため自動化が容易い。

### 何を変更したのか

PR オープン、リ・オープン時に PR 作成者アカウントを `Assignees` にセットする GHA を定義した。

### 技術的にはどこがポイントか

https://github.com/toshimaru/auto-author-assign というそのまんまな GHA が公開されており、これを利用している。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
