### PR TITLE
PDFJS の型エラーを回避する

### DIFF
--- a/packages/core/src/components/dataDisplay/PDFViewer/Page.tsx
+++ b/packages/core/src/components/dataDisplay/PDFViewer/Page.tsx
@@ -63,7 +63,7 @@ function useRenderTextLayer(page: PDFPageProxy, viewport: PageViewport) {
         });
       }
 
-      pdfjsLib.renderTextLayer({ textContent, viewport, container });
+      pdfjsLib.renderTextLayer({ textContent, viewport, container: container as unknown as DocumentFragment });
     })();
   }, [textLayerRef, page, viewport]);
 


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

pdfjs のアプデで型定義が変更され、type assertion しないとコンパイルエラーしてしまう。

### 何を変更したのか

type assertion を入れてコンパイルエラーを回避するようにした。

pdfjs 側のバグにも思えるが、ひとまずワークアラウンドとして対処しておく。

### 技術的にはどこがポイントか

<!-- レビュワーにわかるように、技術的視線での変更概要説明 -->

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
