### PR TITLE
トリガーボタンクリックで listbox が開かないバグを修正する

### DIFF
--- a/packages/core/src/components/navigation/Menu/index.tsx
+++ b/packages/core/src/components/navigation/Menu/index.tsx
@@ -81,8 +81,12 @@ export function useDropdownMenu(itemCount: number, options?: DropdownMenuOptions
     if (!opened) return;
 
     const handleEveryClick = (e: globalThis.MouseEvent) => {
-      if (!(e.target instanceof Element) || e.target.closest('[role="menu"]') instanceof Element) return;
-
+      if (
+        !(e.target instanceof Element) ||
+        e.target === buttonRef.current ||
+        e.target.closest('[role="menu"]') instanceof Element
+      )
+        return;
       setOpened(false);
     };
 

--- a/packages/core/src/hooks/useListBox/index.ts
+++ b/packages/core/src/hooks/useListBox/index.ts
@@ -175,8 +175,13 @@ export function useListBox(itemCount: number): Response {
     if (!active) return;
 
     const handleEveryClick = (e: globalThis.MouseEvent) => {
-      if (!(e.target instanceof Element) || e.target.closest('[role="menu"]') instanceof Element) return;
-      setActive(false);
+      if (
+        !(e.target instanceof Element) ||
+        e.target === triggerRef.current ||
+        e.target.closest('[role="menu"]') instanceof Element
+      )
+        return;
+      setActive(active => !active);
     };
 
     document.addEventListener('click', handleEveryClick);


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

React18 の Concurrent Rendering の影響で `useListBox` のトリガーボタンをクリックしてもリストボックスが開かなくなったため。

### 何を変更したのか

トリガーボタンクリックでリストボックスが期待通り開くよう修正した。

### 技術的にはどこがポイントか

`useEffect` が重複して実行されるようになったことで `active` フラグが `true` になった直後に再度実行されていたのが原因。
`handleEveryClick` 中にて、イベントの発火源がトリガーボタンだったら処理を中断するようにした。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
