### PR TITLE
外部ライブラリの JS を `vendor.js` として切り出してビルドする

### DIFF
--- a/builder/vite.mjs
+++ b/builder/vite.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
-import { build, createServer } from 'vite';
+import { build, createServer, splitVendorChunkPlugin } from 'vite';
 
 /**
  * @typedef {['develop', 'build'][number]} Mode Vite の起動モードを指定します。
@@ -53,6 +53,7 @@ function createBaseConfig(basePath) {
   return {
     root: resolve(basePath, '../'),
     plugins: [
+      splitVendorChunkPlugin(),
       react({
         babel: {
           parserOpts: {


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

外部ライブラリの JS コードはアプリコードほど変更頻度が高くないため、別ファイルとして切り出すことでその部分に対しブラウザキャッシュの有効期限をより長く保持することが期待できる。

### 何を変更したのか

ビルド時に外部ライブラリ（ Vendor ）の JS コードを `vendor.js` として切り出すようにした。

### 技術的にはどこがポイントか

Vite 組み込みプラグインである `splitVendorChunkPlugin` を導入した。これだけで `vendor.js` として切り出されるようになる。

公式ドキュメントによると Vite v2.8 までは何もせずとも切り出されていたが、 v2.9 よりこうした設定が必要となった。


### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

- [Building for Production | Vite](https://vitejs.dev/guide/build.html#chunking-strategy)

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
