### PR TITLE
setup 済み Node を復元する処理を composite action として切り出す

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -1,0 +1,23 @@
+name: Restore Node.js env
+description: Node.js によるタスクランナー基盤を復元する
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set node version
+      shell: bash
+      run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Restore node_modules
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-node-modules
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -1,11 +1,9 @@
 name: Restore Node.js env
 description: Node.js によるタスクランナー基盤を復元する
+
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
     - name: Set node version
       shell: bash
       run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV

--- a/.github/workflows/run_check.yml
+++ b/.github/workflows/run_check.yml
@@ -52,21 +52,6 @@ jobs:
 
       - uses: ./.github/actions/restore-node
 
-      # - name: Set node version
-      #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
-
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: ${{ env.NODE_VERSION }}
-
-      # - name: Restore node_modules
-      #   uses: actions/cache@v3
-      #   env:
-      #     cache-name: cache-node-modules
-      #   with:
-      #     path: node_modules
-      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-
       - name: Run Lint
         run: yarn lint
 
@@ -79,21 +64,6 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: ./.github/actions/restore-node
-
-      # - name: Set node version
-      #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
-
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: ${{ env.NODE_VERSION }}
-
-      # - name: Restore node_modules
-      #   uses: actions/cache@v3
-      #   env:
-      #     cache-name: cache-node-modules
-      #   with:
-      #     path: node_modules
-      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Build icon data
         run: yarn icon build
@@ -111,21 +81,6 @@ jobs:
 
       - uses: ./.github/actions/restore-node
 
-      # - name: Set node version
-      #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
-
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: ${{ env.NODE_VERSION }}
-
-      # - name: Restore node_modules
-      #   uses: actions/cache@v3
-      #   env:
-      #     cache-name: cache-node-modules
-      #   with:
-      #     path: node_modules
-      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-
       - name: Build
         run: yarn mobx build
 
@@ -138,21 +93,6 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: ./.github/actions/restore-node
-
-      # - name: Set node version
-      #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
-
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: ${{ env.NODE_VERSION }}
-
-      # - name: Restore node_modules
-      #   uses: actions/cache@v3
-      #   env:
-      #     cache-name: cache-node-modules
-      #   with:
-      #     path: node_modules
-      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Build icon data
         run: yarn icon build

--- a/.github/workflows/run_check.yml
+++ b/.github/workflows/run_check.yml
@@ -47,9 +47,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - uses: ./.github/actions/restore-node
-      # - name: Checkout
-      #   uses: actions/checkout@v3
 
       # - name: Set node version
       #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
@@ -74,9 +75,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - uses: ./.github/actions/restore-node
-      # - name: Checkout
-      #   uses: actions/checkout@v3
 
       # - name: Set node version
       #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
@@ -104,9 +106,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - uses: ./.github/actions/restore-node
-      # - name: Checkout
-      #   uses: actions/checkout@v3
 
       # - name: Set node version
       #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
@@ -131,9 +134,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - uses: ./.github/actions/restore-node
-      # - name: Checkout
-      #   uses: actions/checkout@v3
 
       # - name: Set node version
       #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV

--- a/.github/workflows/run_check.yml
+++ b/.github/workflows/run_check.yml
@@ -27,9 +27,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Print node version
-        run: node -v
-
       - name: Cache node modules
         uses: actions/cache@v3
         env:
@@ -50,23 +47,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/restore-node
+      # - name: Checkout
+      #   uses: actions/checkout@v3
 
-      - name: Set node version
-        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
+      # - name: Set node version
+      #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
+      # - uses: actions/setup-node@v3
+      #   with:
+      #     node-version: ${{ env.NODE_VERSION }}
 
-      - name: Restore node_modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      # - name: Restore node_modules
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-node-modules
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Run Lint
         run: yarn lint
@@ -76,23 +74,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/restore-node
+      # - name: Checkout
+      #   uses: actions/checkout@v3
 
-      - name: Set node version
-        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
+      # - name: Set node version
+      #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
+      # - uses: actions/setup-node@v3
+      #   with:
+      #     node-version: ${{ env.NODE_VERSION }}
 
-      - name: Restore node_modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      # - name: Restore node_modules
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-node-modules
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Build icon data
         run: yarn icon build
@@ -105,23 +104,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/restore-node
+      # - name: Checkout
+      #   uses: actions/checkout@v3
 
-      - name: Set node version
-        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
+      # - name: Set node version
+      #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
+      # - uses: actions/setup-node@v3
+      #   with:
+      #     node-version: ${{ env.NODE_VERSION }}
 
-      - name: Restore node_modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      # - name: Restore node_modules
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-node-modules
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Build
         run: yarn mobx build
@@ -131,23 +131,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/restore-node
+      # - name: Checkout
+      #   uses: actions/checkout@v3
 
-      - name: Set node version
-        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
+      # - name: Set node version
+      #   run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
+      # - uses: actions/setup-node@v3
+      #   with:
+      #     node-version: ${{ env.NODE_VERSION }}
 
-      - name: Restore node_modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      # - name: Restore node_modules
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-node-modules
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Build icon data
         run: yarn icon build


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

GHA の `run_check` のうち、 `setup` ジョブで作成したタスクランナー基盤を復元する一連の steps を後続ジョブごとに列挙するのがあまりに冗長なため、共通化して切り出したい。

### 何を変更したのか

GHA の Composite Action 機能を使って重複する steps を一つの `action` として切り出し共通化した。

参考: [Creating a composite action - GitHub Docs](https://docs.github.com/ja/actions/creating-actions/creating-a-composite-action)

### 技術的にはどこがポイントか

<!-- レビュワーにわかるように、技術的視線での変更概要説明 -->

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
