### PR TITLE
css-in-js を emotion から linaria に置き換える

### DIFF
--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -1,9 +1,20 @@
 module.exports = {
-  extends: ['stylelint-config-prettier', 'stylelint-config-recess-order', 'stylelint-config-recommended'],
+  extends: [
+    'stylelint-config-prettier',
+    'stylelint-config-recess-order',
+    'stylelint-config-recommended',
+    '@linaria/stylelint',
+  ],
   ignoreFiles: ['**/node_modules/**'],
   customSyntax: '@stylelint/postcss-css-in-js',
   rules: {
     'property-no-vendor-prefix': null,
     'function-no-unknown': null,
+    'selector-pseudo-class-no-unknown': [
+      true,
+      {
+        ignorePseudoClasses: ['global'],
+      },
+    ],
   },
 };

--- a/builder/vite.ts
+++ b/builder/vite.ts
@@ -1,3 +1,4 @@
+import linaria from '@linaria/rollup';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 import type { UserConfig } from 'vite';
@@ -43,6 +44,23 @@ export function createUserConfig({ basePath, port = 3000, define = {} }: Props):
           parserOpts: {
             plugins: ['decorators-legacy', 'classProperties'],
           },
+        },
+      }),
+      linaria({
+        sourceMap: true,
+        babelOptions: {
+          plugins: [
+            // linaria にエイリアスパスを認識させるための措置。
+            [
+              'module-resolver',
+              {
+                alias,
+              },
+            ],
+          ],
+          // パースエラー回避のための措置。
+          // linaria でのスタイル定義内に何かしら型情報が入り込む場合はこの設定が必要となる。
+          presets: ['@babel/preset-typescript'],
         },
       }),
     ],

--- a/cspell.json
+++ b/cspell.json
@@ -23,6 +23,7 @@
     "esbuild",
     "haspopup",
     "hljs",
+    "linaria",
     "meiryo",
     "menlo",
     "monospace",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "wakamsha <wakamsha@gmail.com>",
   "license": "UNLICENSED",
   "private": true,
-  "type": "module",
   "engines": {
     "node": "18.12.1",
     "npm": "please_use_yarn_instead"
@@ -27,7 +26,11 @@
     "format": "prettier -c -w packages/**/*.{ts,tsx}; eslint -c .eslintrc.cjs --fix packages/**/*.{ts,tsx}; stylelint --fix packages/**/*.{ts,tsx}"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "7.18.6",
     "@commitlint/cli": "17.2.0",
+    "@linaria/rollup": "3.0.0-beta.23",
+    "@linaria/shaker": "3.0.0-beta.23",
+    "@linaria/stylelint": "3.0.0-beta.23",
     "@stylelint/postcss-css-in-js": "0.38.0",
     "@types/jest": "29.2.2",
     "@types/node": "18.11.9",
@@ -37,6 +40,8 @@
     "@typescript-eslint/eslint-plugin": "5.42.1",
     "@typescript-eslint/parser": "5.42.1",
     "@vitejs/plugin-react": "2.2.0",
+    "babel-loader": "9.1.0",
+    "babel-plugin-module-resolver": "4.1.0",
     "cheerio": "1.0.0-rc.12",
     "chokidar": "3.5.3",
     "cspell": "6.14.2",
@@ -72,7 +77,7 @@
     "yargs": "17.6.2"
   },
   "dependencies": {
-    "@emotion/css": "11.10.5",
+    "@linaria/core": "3.0.0-beta.22",
     "constate": "3.3.2",
     "csx": "10.0.2",
     "date-fns": "2.29.3",

--- a/packages/catalog/index.html
+++ b/packages/catalog/index.html
@@ -6,10 +6,6 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <meta name="description" content="goodbye world" />
     <title>Catalog | Learn React</title>
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/atom-one-dark.min.css"
-    />
   </head>
 
   <body>

--- a/packages/catalog/src/components/Layout/index.tsx
+++ b/packages/catalog/src/components/Layout/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ReactNode } from 'react';
 import { Navigation } from '../Navigation';
 

--- a/packages/catalog/src/components/Navigation/index.tsx
+++ b/packages/catalog/src/components/Navigation/index.tsx
@@ -1,8 +1,8 @@
-import { css } from '@emotion/css';
 import { Icon } from '@learn-react/core/components/dataDisplay/Icon';
 import { TextField } from '@learn-react/core/components/inputs/TextField';
 import { BorderRadius, Duration, FontFamily, FontSize, IconSize } from '@learn-react/core/constants/Style';
 import { cssVar, gutter, square } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { FC } from 'react';
 import { useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';

--- a/packages/catalog/src/pages/IndexPage.tsx
+++ b/packages/catalog/src/pages/IndexPage.tsx
@@ -1,7 +1,7 @@
-import { css } from '@emotion/css';
 import { SplashBanner } from '@learn-react/core/components/surfaces/SplashBanner';
 import { DocumentTitle } from '@learn-react/core/components/utils/DocumentTitle';
 import { cssVar } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 
 export const IndexPage = () => (
   <>

--- a/packages/catalog/src/pages/StoryPage/CodeBlock.tsx
+++ b/packages/catalog/src/pages/StoryPage/CodeBlock.tsx
@@ -18,6 +18,19 @@ export const CodeBlock = ({ children }: Props) => {
     }
   });
 
+  useEffect(() => {
+    // html ファイルにハードコーディングすると `vite build` 時に Linaria が失敗するため、
+    // これを回避するため動的に `<link>` 要素を生成して挿入する。
+    if (!document.querySelector('link#highlight-theme')) {
+      const dom = document.createElement('link');
+      dom.rel = 'stylesheet';
+      dom.id = 'highlight-theme';
+      dom.href = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/atom-one-dark.min.css';
+
+      document.head.append(dom);
+    }
+  }, []);
+
   return (
     <pre className={styleBase}>
       <code className="typescript" ref={ref}>

--- a/packages/catalog/src/pages/StoryPage/CodeBlock.tsx
+++ b/packages/catalog/src/pages/StoryPage/CodeBlock.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import { FontFamily, LineHeight } from '@learn-react/core/constants/Style';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import hljs from 'highlight.js';
 import { useEffect, useRef } from 'react';
 

--- a/packages/catalog/src/pages/StoryPage/LayoutSwitch.tsx
+++ b/packages/catalog/src/pages/StoryPage/LayoutSwitch.tsx
@@ -1,5 +1,5 @@
-import { css, cx } from '@emotion/css';
 import { cssVar, gutter, square } from '@learn-react/core/helpers/Style';
+import { css, cx } from '@linaria/core';
 import type { MouseEvent } from 'react';
 import { LayoutConfigContainer } from './LayoutConfigContainer';
 import { Layout } from './VO';

--- a/packages/catalog/src/pages/StoryPage/index.tsx
+++ b/packages/catalog/src/pages/StoryPage/index.tsx
@@ -1,7 +1,7 @@
-import { css, cx } from '@emotion/css';
 import { DocumentTitle } from '@learn-react/core/components/utils/DocumentTitle';
 import { BorderRadius, FontFamily, FontSize, LineHeight } from '@learn-react/core/constants/Style';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
+import { css, cx } from '@linaria/core';
 import type { FC } from 'react';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';

--- a/packages/core/src/components/dataDisplay/Icon/index.story.tsx
+++ b/packages/core/src/components/dataDisplay/Icon/index.story.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import type { IconName } from '@learn-react/icon';
 import { iconElements } from '@learn-react/icon';
+import { css } from '@linaria/core';
 import { Icon } from '.';
 import { FontSize } from '../../../constants/Style';
 import { cssVar, gutter, square } from '../../../helpers/Style';

--- a/packages/core/src/components/dataDisplay/PDFViewer/Page.tsx
+++ b/packages/core/src/components/dataDisplay/PDFViewer/Page.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import * as pdfjsLib from 'pdfjs-dist';
 import type { PDFPageProxy, TextContent, TextStyle } from 'pdfjs-dist/types/src/display/api';
 import type { PageViewport } from 'pdfjs-dist/types/src/display/display_utils';

--- a/packages/core/src/components/dataDisplay/PDFViewer/index.tsx
+++ b/packages/core/src/components/dataDisplay/PDFViewer/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import * as pdfjsLib from 'pdfjs-dist';
 import workerUrl from 'pdfjs-dist/build/pdf.worker.min.js?url';
 import type { PDFPageProxy } from 'pdfjs-dist/types/src/display/api';

--- a/packages/core/src/components/dataDisplay/Tooltip/index.story.tsx
+++ b/packages/core/src/components/dataDisplay/Tooltip/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { useState } from 'react';
 import { Tooltip } from '.';
 import { gutter, square } from '../../../helpers/Style';

--- a/packages/core/src/components/dataDisplay/Tooltip/index.tsx
+++ b/packages/core/src/components/dataDisplay/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/packages/core/src/components/feedback/Preloader/index.tsx
+++ b/packages/core/src/components/feedback/Preloader/index.tsx
@@ -1,4 +1,4 @@
-import { css, keyframes } from '@emotion/css';
+import { css } from '@linaria/core';
 import { cssVar } from '../../../helpers/Style';
 
 type Size = 'neutral' | 'button';
@@ -40,39 +40,39 @@ export const Preloader = ({ size = 'neutral', theme = 'neutral' }: Props) => {
 
 const baseSize = 50;
 
-const rotateAnimation = keyframes`
-  from {
-    transform: rotateZ(0);
-  }
-  to {
-    transform: rotateZ(360deg);
-  }
-`;
-
-const dashAnimation = keyframes`
-  0% {
-    stroke-dasharray: 1, 200;
-    stroke-dashoffset: 0;
-  }
-  50% {
-    stroke-dasharray: 89, 200;
-    stroke-dashoffset: -35;
-  }
-  100% {
-    stroke-dasharray: 89, 200;
-    stroke-dashoffset: -124;
-  }
-`;
-
 const styleBase = css`
-  animation: ${rotateAnimation} 1.4s linear infinite;
+  animation: rotateAnimation 1.4s linear infinite;
+
+  @keyframes rotateAnimation {
+    from {
+      transform: rotateZ(0);
+    }
+    to {
+      transform: rotateZ(360deg);
+    }
+  }
 `;
 
 const stylePath = css`
   stroke-dasharray: 1, 800;
   stroke-dashoffset: 0;
   stroke-linecap: round;
-  animation: ${dashAnimation} 1.5s ease-in-out infinite, color 6s ease-in-out infinite;
+  animation: dashAnimation 1.5s ease-in-out infinite, color 6s ease-in-out infinite;
+
+  @keyframes dashAnimation {
+    0% {
+      stroke-dasharray: 1, 200;
+      stroke-dashoffset: 0;
+    }
+    50% {
+      stroke-dasharray: 89, 200;
+      stroke-dashoffset: -35;
+    }
+    100% {
+      stroke-dasharray: 89, 200;
+      stroke-dashoffset: -124;
+    }
+  }
 `;
 
 const styleSize: Frozen<Size, number> = {

--- a/packages/core/src/components/feedback/Toast/Container.tsx
+++ b/packages/core/src/components/feedback/Toast/Container.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { createPortal } from 'react-dom';
 import { useToasts } from '.';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/feedback/Toast/Item.tsx
+++ b/packages/core/src/components/feedback/Toast/Item.tsx
@@ -1,4 +1,4 @@
-import { css, cx, keyframes } from '@emotion/css';
+import { css, cx } from '@linaria/core';
 import type { AnimationEvent, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import type { Toast } from '.';
@@ -52,16 +52,18 @@ const styleBase = css`
   font-size: ${FontSize.Regular};
   color: white;
   box-shadow: ${cssVar('ShadowNeutral')};
-  animation: ${keyframes`
+  animation: baseAnimation ${Duration.Enter} ${Easing.Enter};
+
+  @keyframes baseAnimation {
     from {
-      opacity: ${0};
+      opacity: 0;
       transform: translate3d(-10%, 0, 0);
     }
     to {
-      opacity: ${1};
+      opacity: 1;
       transform: translate3d(0, 0, 0);
     }
-  `} ${Duration.Enter} ${Easing.Enter};
+  }
 
   > :not(:first-child) {
     margin-left: ${gutter(1)};
@@ -78,16 +80,18 @@ const styleRemove = cx(
   styleBase,
   css`
     opacity: 0;
-    animation: ${keyframes`
-    from {
-      opacity: ${1};
-      transform: translate3d(0, 0, 0);
+    animation: removeAnimation ${Duration.Leave} ${Easing.Leave};
+
+    @keyframes removeAnimation {
+      from {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+      }
+      to {
+        opacity: 0;
+        transform: translate3d(-40%, 0, 0);
+      }
     }
-    to {
-      opacity: ${0};
-      transform: translate3d(-40%, 0, 0);
-    }
-  `} ${Duration.Leave} ${Easing.Leave};
   `,
 );
 

--- a/packages/core/src/components/feedback/Toast/index.story.tsx
+++ b/packages/core/src/components/feedback/Toast/index.story.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import type { IconName } from '@learn-react/icon';
 import { iconElements } from '@learn-react/icon';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { useMemo, useReducer, useState } from 'react';
 import type { Toast } from '.';

--- a/packages/core/src/components/feedback/ToastLegacy/Container.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy/Container.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { createPortal } from 'react-dom';
 import type { Toast } from '.';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/feedback/ToastLegacy/Item.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy/Item.tsx
@@ -1,4 +1,4 @@
-import { css, cx, keyframes } from '@emotion/css';
+import { css, cx } from '@linaria/core';
 import type { AnimationEvent, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { Toast } from '.';
@@ -50,16 +50,18 @@ const styleBase = css`
   padding: ${gutter(4)} ${gutter(5)} ${gutter(4)} ${gutter(4)};
   color: white;
   box-shadow: ${cssVar('ShadowNeutral')};
-  animation: ${keyframes`
+  animation: baseAnimation ${Duration.Enter} ${Easing.Enter};
+
+  @keyframes baseAnimation {
     from {
-      opacity: ${0};
+      opacity: 0;
       transform: translate3d(-10%, 0, 0);
     }
     to {
-      opacity: ${1};
+      opacity: 1;
       transform: translate3d(0, 0, 0);
     }
-  `} ${Duration.Enter} ${Easing.Enter};
+  }
 
   > :not(:first-child) {
     margin-left: ${gutter(1)};
@@ -76,16 +78,18 @@ const styleRemove = cx(
   styleBase,
   css`
     opacity: 0;
-    animation: ${keyframes`
-    from {
-      opacity: ${1};
-      transform: translate3d(0, 0, 0);
+    animation: removeAnimation ${Duration.Leave} ${Easing.Leave};
+
+    @keyframes removeAnimation {
+      from {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+      }
+      to {
+        opacity: 0;
+        transform: translate3d(-40%, 0, 0);
+      }
     }
-    to {
-      opacity: ${0};
-      transform: translate3d(-40%, 0, 0);
-    }
-  `} ${Duration.Leave} ${Easing.Leave};
   `,
 );
 

--- a/packages/core/src/components/feedback/ToastLegacy/index.story.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy/index.story.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import type { IconName } from '@learn-react/icon';
 import { iconElements } from '@learn-react/icon';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { useMemo, useReducer, useState } from 'react';
 import { Toast } from '.';

--- a/packages/core/src/components/feedback/ToastLegacy2/Container.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy2/Container.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { createPortal } from 'react-dom';
 import { Toast } from '.';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/feedback/ToastLegacy2/Item.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy2/Item.tsx
@@ -1,4 +1,4 @@
-import { css, cx, keyframes } from '@emotion/css';
+import { css, cx } from '@linaria/core';
 import type { AnimationEvent, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { Toast } from '.';
@@ -50,16 +50,18 @@ const styleBase = css`
   padding: ${gutter(4)} ${gutter(5)} ${gutter(4)} ${gutter(4)};
   color: white;
   box-shadow: ${cssVar('ShadowNeutral')};
-  animation: ${keyframes`
+  animation: baseAnimation ${Duration.Enter} ${Easing.Enter};
+
+  @keyframes baseAnimation {
     from {
-      opacity: ${0};
+      opacity: 0;
       transform: translate3d(-10%, 0, 0);
     }
     to {
-      opacity: ${1};
+      opacity: 1;
       transform: translate3d(0, 0, 0);
     }
-  `} ${Duration.Enter} ${Easing.Enter};
+  }
 
   > :not(:first-child) {
     margin-left: ${gutter(1)};
@@ -76,16 +78,18 @@ const styleRemove = cx(
   styleBase,
   css`
     opacity: 0;
-    animation: ${keyframes`
-    from {
-      opacity: ${1};
-      transform: translate3d(0, 0, 0);
+    animation: removeAnimation ${Duration.Leave} ${Easing.Leave};
+
+    @keyframes removeAnimation {
+      from {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+      }
+      to {
+        opacity: 0;
+        transform: translate3d(-40%, 0, 0);
+      }
     }
-    to {
-      opacity: ${0};
-      transform: translate3d(-40%, 0, 0);
-    }
-  `} ${Duration.Leave} ${Easing.Leave};
   `,
 );
 

--- a/packages/core/src/components/feedback/ToastLegacy2/index.story.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy2/index.story.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import type { IconName } from '@learn-react/icon';
 import { iconElements } from '@learn-react/icon';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { useMemo, useReducer, useState } from 'react';
 import { Toast } from '.';

--- a/packages/core/src/components/inputs/Button/index.story.tsx
+++ b/packages/core/src/components/inputs/Button/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { Button } from '.';
 import { gutter } from '../../../helpers/Style';
 import { Icon } from '../../dataDisplay/Icon';

--- a/packages/core/src/components/inputs/Button/index.tsx
+++ b/packages/core/src/components/inputs/Button/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx } from '@linaria/core';
 import type { ButtonHTMLAttributes, MouseEvent, ReactNode } from 'react';
 import { Children, useMemo } from 'react';
 import { BorderRadius, Duration, FontSize } from '../../../constants/Style';
@@ -79,7 +79,7 @@ function getVariantStyle(variant: Variant, theme: Theme) {
 }
 
 function variantSolid(neutral: ReturnType<typeof cssVar>, hover: ReturnType<typeof cssVar>) {
-  return css`
+  return `
     color: white;
     background-color: ${neutral};
     border-color: ${neutral};
@@ -108,7 +108,7 @@ function variantSolid(neutral: ReturnType<typeof cssVar>, hover: ReturnType<type
 }
 
 function variantGhost(color: ReturnType<typeof cssVar>, hover: ReturnType<typeof cssVar>) {
-  return css`
+  return `
     color: ${color};
     background-color: transparent;
     border-color: ${color};
@@ -136,7 +136,7 @@ function variantGhost(color: ReturnType<typeof cssVar>, hover: ReturnType<typeof
 }
 
 function variantBare(color: ReturnType<typeof cssVar>, hover: ReturnType<typeof cssVar>) {
-  return css`
+  return `
     color: ${color};
     background-color: transparent;
     border-color: transparent;
@@ -203,18 +203,30 @@ const styleBase = css`
 `;
 
 const styleSolid: Frozen<Theme, string> = {
-  primary: variantSolid(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryDark')),
-  danger: variantSolid(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerDark')),
+  primary: css`
+    ${variantSolid(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryDark'))}
+  `,
+  danger: css`
+    ${variantSolid(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerDark'))}
+  `,
 };
 
 const styleGhost: Frozen<Theme, string> = {
-  primary: variantGhost(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryLight')),
-  danger: variantGhost(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerLight')),
+  primary: css`
+    ${variantGhost(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryLight'))}
+  `,
+  danger: css`
+    ${variantGhost(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerLight'))}
+  `,
 };
 
 const styleBare: Frozen<Theme, string> = {
-  primary: variantBare(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryLight')),
-  danger: variantBare(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerLight')),
+  primary: css`
+    ${variantBare(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryLight'))}
+  `,
+  danger: css`
+    ${variantBare(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerLight'))}
+  `,
 };
 
 const styleBlock = css`

--- a/packages/core/src/components/inputs/Calendar/Item.tsx
+++ b/packages/core/src/components/inputs/Calendar/Item.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { BorderRadius, Duration, FontSize, IconSize } from '../../../constants/Style';
 import { cssVar, square } from '../../../helpers/Style';
 

--- a/packages/core/src/components/inputs/Calendar/index.tsx
+++ b/packages/core/src/components/inputs/Calendar/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import {
   addMonths,
   endOfDay,

--- a/packages/core/src/components/inputs/Checkbox/index.tsx
+++ b/packages/core/src/components/inputs/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ChangeEvent, ReactNode } from 'react';
 import { useEffect, useRef } from 'react';
 import { BorderRadius, Duration, FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/inputs/ComboBox/index.tsx
+++ b/packages/core/src/components/inputs/ComboBox/index.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import type { IconName } from '@learn-react/icon';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { useId, useState } from 'react';
 import { Duration, FontSize, IconSize, LineHeight } from '../../../constants/Style';

--- a/packages/core/src/components/inputs/FormLabel/index.story.tsx
+++ b/packages/core/src/components/inputs/FormLabel/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { useId } from 'react';
 import { FormLabel } from '.';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/FormLabel/index.tsx
+++ b/packages/core/src/components/inputs/FormLabel/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ReactNode } from 'react';
 import { useId } from 'react';
 import { Icon } from '../../../components/dataDisplay/Icon';

--- a/packages/core/src/components/inputs/IconButton/index.story.tsx
+++ b/packages/core/src/components/inputs/IconButton/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { IconButton } from '.';
 import { gutter } from '../../../helpers/Style';
 

--- a/packages/core/src/components/inputs/IconButton/index.tsx
+++ b/packages/core/src/components/inputs/IconButton/index.tsx
@@ -1,5 +1,5 @@
-import { css, cx } from '@emotion/css';
 import type { IconName } from '@learn-react/icon';
+import { css, cx } from '@linaria/core';
 import type { MouseEvent } from 'react';
 import { useMemo } from 'react';
 import { BorderRadius, Duration } from '../../../constants/Style';
@@ -77,7 +77,7 @@ function getVariantStyle(variant: Variant, theme: Theme) {
 }
 
 function variantSolid(neutral: ReturnType<typeof cssVar>, hover: ReturnType<typeof cssVar>) {
-  return css`
+  return `
     background-color: ${neutral};
     border-color: ${neutral};
 
@@ -99,7 +99,7 @@ function variantSolid(neutral: ReturnType<typeof cssVar>, hover: ReturnType<type
 }
 
 function variantGhost(color: ReturnType<typeof cssVar>, hover: ReturnType<typeof cssVar>) {
-  return css`
+  return `
     border-color: ${color};
 
     > svg {
@@ -121,7 +121,7 @@ function variantGhost(color: ReturnType<typeof cssVar>, hover: ReturnType<typeof
 }
 
 function variantBare(color: ReturnType<typeof cssVar>, hover: ReturnType<typeof cssVar>) {
-  return css`
+  return `
     > svg {
       fill: ${color};
     }
@@ -163,18 +163,30 @@ const styleBase = css`
 `;
 
 const styleSolid: Frozen<Theme, string> = {
-  primary: variantSolid(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryDark')),
-  danger: variantSolid(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerDark')),
+  primary: css`
+    ${variantSolid(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryDark'))}
+  `,
+  danger: css`
+    ${variantSolid(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerDark'))}
+  `,
 };
 
 const styleGhost: Frozen<Theme, string> = {
-  primary: variantGhost(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryLight')),
-  danger: variantGhost(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerLight')),
+  primary: css`
+    ${variantGhost(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryLight'))}
+  `,
+  danger: css`
+    ${variantGhost(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerLight'))}
+  `,
 };
 
 const styleBare: Frozen<Theme, string> = {
-  primary: variantBare(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryLight')),
-  danger: variantBare(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerLight')),
+  primary: css`
+    ${variantBare(cssVar('ThemePrimaryNeutral'), cssVar('ThemePrimaryLight'))}
+  `,
+  danger: css`
+    ${variantBare(cssVar('ThemeDangerNeutral'), cssVar('ThemeDangerLight'))}
+  `,
 };
 
 const styleSize: Frozen<Size, string> = {

--- a/packages/core/src/components/inputs/LabeledSlider/index.tsx
+++ b/packages/core/src/components/inputs/LabeledSlider/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 
 type Props = {

--- a/packages/core/src/components/inputs/Radio/index.tsx
+++ b/packages/core/src/components/inputs/Radio/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ChangeEvent, ReactNode } from 'react';
 import { BorderRadius, Duration, FontSize } from '../../../constants/Style';
 import { cssVar, gutter, square } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/Range/index.tsx
+++ b/packages/core/src/components/inputs/Range/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { BorderRadius, Duration } from '../../../constants/Style';
 import { cssVar, square } from '../../../helpers/Style';
@@ -23,34 +23,50 @@ type Props = {
 export const Range = ({ value, onChange, min = 0, max = 100, step = 1, disabled, theme = 'primary' }: Props) => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => onChange(Number(e.target.value));
 
+  const ratio = (value / max) * 100;
+
   return (
-    <input
-      className={cx(styleBase, filledTrack(styleTheme[theme], (value / max) * 100))}
-      type="range"
-      value={value}
-      onChange={handleChange}
-      min={min}
-      max={max}
-      step={step}
-      disabled={disabled}
-    />
+    <div className={styleWrapper}>
+      <input
+        className={styleBase}
+        type="range"
+        value={value}
+        onChange={handleChange}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+      />
+      <div
+        style={{
+          background: `linear-gradient(to right, ${styleTheme[theme]} 0%, ${styleTheme[theme]} ${ratio}%, ${cssVar(
+            'LineNeutral',
+          )} ${ratio}%)`,
+        }}
+        className={styleTrack}
+      />
+    </div>
   );
 };
 
-function filledTrack(color: ReturnType<typeof cssVar>, ratio: number) {
-  return css({
-    '&::-webkit-slider-runnable-track': {
-      background: `linear-gradient(to right, ${color} 0%, ${color} ${ratio}%, ${cssVar('LineNeutral')} ${ratio}%)`,
-    },
-    '&::-moz-range-track': {
-      background: `linear-gradient(to right, ${color} 0%, ${color} ${ratio}%, ${cssVar('LineNeutral')} ${ratio}%)`,
-    },
-  });
-}
+const styleWrapper = css`
+  position: relative;
+`;
+
+const styleTrack = css`
+  position: absolute;
+  top: 50%;
+  left: 0;
+  z-index: 1;
+  width: 100%;
+  height: 2px;
+  transform: translate3d(0, -2px, 0);
+`;
 
 const diameter = 24;
 
-const thumb = css`
+const thumb = `
+  -webkit-appearance: none;
   margin-top: -${diameter / 2}px;
   cursor: pointer;
   background-color: white;
@@ -65,17 +81,17 @@ const thumb = css`
   }
 `;
 
-const track = css`
+const track = `
   width: 100%;
   height: 2px;
-  background-color: ${cssVar('LineNeutral')};
+  background-color: transparent;
   border: none;
-  border-radius: ${BorderRadius.Circle};
 `;
 
 const styleBase = css`
   -webkit-appearance: none;
   position: relative;
+  z-index: 2;
   width: 100%;
   height: ${diameter}px;
   margin: 0;
@@ -83,7 +99,6 @@ const styleBase = css`
   outline: none;
 
   &::-webkit-slider-thumb {
-    -webkit-appearance: none;
     ${thumb}
   }
 

--- a/packages/core/src/components/inputs/Select/index.tsx
+++ b/packages/core/src/components/inputs/Select/index.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import type { IconName } from '@learn-react/icon';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { useMemo } from 'react';
 import { Duration, FontSize, LineHeight } from '../../../constants/Style';

--- a/packages/core/src/components/inputs/TextArea/index.story.tsx
+++ b/packages/core/src/components/inputs/TextArea/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { useState } from 'react';
 import { TextArea } from '.';
 import { FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/inputs/TextArea/index.tsx
+++ b/packages/core/src/components/inputs/TextArea/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { Duration, FontSize, LineHeight } from '../../../constants/Style';
 import { cssVar, gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/TextField/index.story.tsx
+++ b/packages/core/src/components/inputs/TextField/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { useState } from 'react';
 import { TextField } from '.';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/TextField/index.tsx
+++ b/packages/core/src/components/inputs/TextField/index.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import type { IconName } from '@learn-react/icon';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { Duration, FontSize, LineHeight } from '../../../constants/Style';
 import { cssVar, gutter, square } from '../../../helpers/Style';

--- a/packages/core/src/components/navigation/Menu/index.story.tsx
+++ b/packages/core/src/components/navigation/Menu/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { useState } from 'react';
 import { useDropdownMenu } from '.';
 import { FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/navigation/Sidebar/index.tsx
+++ b/packages/core/src/components/navigation/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx } from '@linaria/core';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { BorderRadius, Duration, FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/navigation/Tabs/index.tsx
+++ b/packages/core/src/components/navigation/Tabs/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { useId } from 'react';
 import { Duration, FontSize, LineHeight } from '../../../constants/Style';

--- a/packages/core/src/components/surfaces/Card/index.story.tsx
+++ b/packages/core/src/components/surfaces/Card/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { Card } from '.';
 import { FontSize, LineHeight } from '../../../constants/Style';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/surfaces/Card/index.tsx
+++ b/packages/core/src/components/surfaces/Card/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx } from '@linaria/core';
 import type { CSSProperties, ReactNode } from 'react';
 import { Duration, Easing } from '../../../constants/Style';
 import { cssVar, gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/surfaces/SplashBanner/index.tsx
+++ b/packages/core/src/components/surfaces/SplashBanner/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { FontSize } from '../../../constants/Style';
 import { gutter } from '../../../helpers/Style';
 

--- a/packages/core/src/components/utils/Box/index.tsx
+++ b/packages/core/src/components/utils/Box/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ReactNode } from 'react';
 
 type Props = {

--- a/packages/core/src/components/utils/Modal/index.story.tsx
+++ b/packages/core/src/components/utils/Modal/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { useState } from 'react';
 import { Modal } from '.';
 import { FontSize, LineHeight } from '../../../constants/Style';

--- a/packages/core/src/components/utils/Modal/index.tsx
+++ b/packages/core/src/components/utils/Modal/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';

--- a/packages/core/src/components/utils/Popover/index.story.tsx
+++ b/packages/core/src/components/utils/Popover/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ComponentProps, MouseEvent } from 'react';
 import { useState } from 'react';
 import { Popover } from '.';

--- a/packages/core/src/components/utils/Popover/index.tsx
+++ b/packages/core/src/components/utils/Popover/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx } from '@linaria/core';
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/packages/core/src/components/utils/SplitPane/Pane.tsx
+++ b/packages/core/src/components/utils/SplitPane/Pane.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
 import { forwardRef } from 'react';
 import type { SplitPane } from '.';

--- a/packages/core/src/components/utils/SplitPane/Splitter.tsx
+++ b/packages/core/src/components/utils/SplitPane/Splitter.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ComponentProps, MouseEvent } from 'react';
 import type { SplitPane } from '.';
 import { Duration } from '../../../constants/Style';

--- a/packages/core/src/components/utils/SplitPane/index.tsx
+++ b/packages/core/src/components/utils/SplitPane/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx } from '@linaria/core';
 import type { MouseEvent, ReactNode } from 'react';
 import { Children, useRef, useState } from 'react';
 import { Pane } from './Pane';

--- a/packages/core/src/components/utils/Transition/index.story.tsx
+++ b/packages/core/src/components/utils/Transition/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { useState } from 'react';
 import { Transition } from '.';
 import { FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/utils/Transition/index.tsx
+++ b/packages/core/src/components/utils/Transition/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ReactNode } from 'react';
 import { useMemo, useRef, useState } from 'react';
 import { Duration, Easing } from '../../../constants/Style';

--- a/packages/core/src/constants/Style/index.story.tsx
+++ b/packages/core/src/constants/Style/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { Color, FontSize, LineHeight } from '.';
 import { cssVar, gutter, textEllipsis } from '../../helpers/Style';
 

--- a/packages/core/src/helpers/Style.ts
+++ b/packages/core/src/helpers/Style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css';
+import { css } from '@linaria/core';
 import { color } from 'csx';
 import { Color, FontFamily, Shadow } from '../constants/Style';
 import NotoSansMedium from './fonts/noto-sans/NotoSansJP-Medium.woff';
@@ -37,10 +37,12 @@ export function gutter(value: number): string {
  * @param value 一辺の長さ
  */
 export function square(value: string | number) {
-  return {
-    width: value,
-    height: value,
-  };
+  const side = typeof value === 'number' ? `${value}px` : value;
+
+  return `
+    width: ${side};
+    height: ${side};
+  `;
 }
 
 /**
@@ -88,148 +90,144 @@ export function textEllipsis() {
  * @see https://github.com/hankchizljaw/modern-css-reset/blob/master/dist/reset.min.css
  */
 export function applyResetStyle() {
-  return injectGlobal`
-    *,
-    *:before,
-    *:after {
-      box-sizing: border-box;
-      margin: 0;
-    }
-    html {
-      overflow-x: hidden;
-      font-family: sans-serif;
-      -webkit-text-size-adjust: 100%;
-      -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-      scroll-behavior: smooth;
-    }
-    body {
-      min-height: 100vh;
-      text-rendering: optimizeSpeed;
-      line-height: 1.5;
-    }
-    a:not([class]) {
-      text-decoration-skip-ink: auto;
-    }
-    img,
-    picture {
-      display: block;
-      max-width: 100%;
-    }
-    input,
-    button,
-    textarea,
-    select {
-      font: inherit;
-
-      &:focus:not(:focus-visible) {
-        /* キーボード操作"以外"でフォーカスされた際は outline を消す */
-        outline: 0;
+  return css`
+    :global() {
+      *,
+      *:before,
+      *:after {
+        box-sizing: border-box;
+        margin: 0;
       }
-    }
-    main {
-      display: block;
-      overflow-x: hidden;
+      html {
+        overflow-x: hidden;
+        font-family: sans-serif;
+        -webkit-text-size-adjust: 100%;
+        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+        scroll-behavior: smooth;
+      }
+      body {
+        min-height: 100vh;
+        text-rendering: optimizeSpeed;
+        line-height: 1.5;
+      }
+      a:not([class]) {
+        text-decoration-skip-ink: auto;
+      }
+      img,
+      picture {
+        display: block;
+        max-width: 100%;
+      }
+      input,
+      button,
+      textarea,
+      select {
+        font: inherit;
+
+        &:focus:not(:focus-visible) {
+          /* キーボード操作"以外"でフォーカスされた際は outline を消す */
+          outline: 0;
+        }
+      }
+      main {
+        display: block;
+        overflow-x: hidden;
+      }
     }
   `;
 }
 
 export function applyGlobalStyle() {
-  return injectGlobal`
-    @font-face {
-      font-family: 'Noto Sans Japanese';
-      font-style: normal;
-      font-weight: normal;
-      src: local('Noto Sans Japanese'),
-        url(${NotoSansRegular}) format('woff');
-      font-display: swap;
-    }
-    @font-face {
-      font-family: 'Noto Sans Japanese';
-      font-style: normal;
-      font-weight: bold;
-      src: local('Noto Sans Japanese Bold'),
-        url(${NotoSansMedium}) format('woff');
-      font-display: swap;
-    }
-    @font-face {
-      font-family: 'Noto Serif Japanese';
-      font-style: normal;
-      font-weight: normal;
-      src: local('Noto Serif Japanese'),
-        url(${NotoSerifRegular}) format('woff');
-      font-display: swap;
-    }
-    @font-face {
-      font-family: 'Noto Serif Japanese';
-      font-style: normal;
-      font-weight: bold;
-      src: local('Noto Serif Japanese Bold'),
-        url(${NotoSerifSemiBold}) format('woff');
-      font-display: swap;
-    }
+  return css`
+    :global() {
+      @font-face {
+        font-family: 'Noto Sans Japanese';
+        font-style: normal;
+        font-weight: normal;
+        src: local('Noto Sans Japanese'), url(${NotoSansRegular}) format('woff');
+        font-display: swap;
+      }
+      @font-face {
+        font-family: 'Noto Sans Japanese';
+        font-style: normal;
+        font-weight: bold;
+        src: local('Noto Sans Japanese Bold'), url(${NotoSansMedium}) format('woff');
+        font-display: swap;
+      }
+      @font-face {
+        font-family: 'Noto Serif Japanese';
+        font-style: normal;
+        font-weight: normal;
+        src: local('Noto Serif Japanese'), url(${NotoSerifRegular}) format('woff');
+        font-display: swap;
+      }
+      @font-face {
+        font-family: 'Noto Serif Japanese';
+        font-style: normal;
+        font-weight: bold;
+        src: local('Noto Serif Japanese Bold'), url(${NotoSerifSemiBold}) format('woff');
+        font-display: swap;
+      }
 
-    :root {
-      ${css(
-        Object.entries({ ...Color, ...Shadow }).reduce(
+      :root {
+        ${Object.entries({ ...Color, ...Shadow }).reduce(
           (acc, [key, value]) => ({
             ...acc,
             [`--${key}`]: value.light,
           }),
           {},
-        ),
-      )}
-    }
+        )}
+      }
 
-    @media (prefers-color-scheme: dark) {
-      :root {
-        color-scheme: dark;
+      @media (prefers-color-scheme: dark) {
+        :root {
+          color-scheme: dark;
 
-        ${css(
-          Object.entries({ ...Color, ...Shadow }).reduce(
+          ${Object.entries({ ...Color, ...Shadow }).reduce(
             (acc, [key, value]) => ({
               ...acc,
               [`--${key}`]: value.dark,
             }),
             {},
-          ),
-        )}
+          )}
+        }
       }
-    }
 
-    html,
-    body {
-      padding: 0;
-      margin: 0;
-      font-family: ${FontFamily.Default};
-      font-weight: 500;
-      font-feature-settings: palt 1;
-    }
-    body,
-    h1,
-    h2,
-    h3,
-    h4,
-    p,
-    ul,
-    ol,
-    figure,
-    blockquote,
-    dl,
-    dd {
-      margin: 0;
-    }
-    ul,
-    ol {
-      padding: 0;
-      list-style: none;
-    }
-    /* stylelint-disable-next-line no-descending-specificity */
-    a {
-      color: inherit;
-      text-decoration: none;
+      html,
+      body {
+        padding: 0;
+        margin: 0;
+        font-family: ${FontFamily.Default};
+        font-weight: 500;
+        font-feature-settings: palt 1;
+      }
+      body,
+      h1,
+      h2,
+      h3,
+      h4,
+      p,
+      ul,
+      ol,
+      figure,
+      blockquote,
+      dl,
+      dd {
+        margin: 0;
+      }
+      ul,
+      ol {
+        padding: 0;
+        list-style: none;
+      }
+      /* stylelint-disable-next-line no-descending-specificity */
+      a {
+        color: inherit;
+        text-decoration: none;
 
-      &:hover {
-        text-decoration: underline;
+        &:hover {
+          text-decoration: underline;
+        }
       }
     }
   `;

--- a/packages/core/src/helpers/Style.ts
+++ b/packages/core/src/helpers/Style.ts
@@ -79,7 +79,7 @@ export function visuallyHidden() {
 }
 
 export function textEllipsis() {
-  return css`
+  return `
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/core/src/hooks/useData/index.story.tsx
+++ b/packages/core/src/hooks/useData/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { Suspense, useState, useTransition } from 'react';
 import { useData } from '.';

--- a/packages/core/src/hooks/useHotkeys/index.story.tsx
+++ b/packages/core/src/hooks/useHotkeys/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { useState } from 'react';
 import { useHotkeys } from '.';
 import { Modal } from '../../components/utils/Modal';

--- a/packages/core/src/hooks/useListBox/index.story.tsx
+++ b/packages/core/src/hooks/useListBox/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import { useState } from 'react';
 import { useListBox } from '.';
 import { FontSize } from '../../constants/Style';

--- a/packages/core/src/hooks/useShuffleLetters/index.story.tsx
+++ b/packages/core/src/hooks/useShuffleLetters/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css } from '@linaria/core';
 import type { ReactNode } from 'react';
 import { useRef, useState } from 'react';
 import { useShuffleLetters } from '.';

--- a/packages/routing/src/01-basic/components/Navigation.tsx
+++ b/packages/routing/src/01-basic/components/Navigation.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { Link } from 'react-router-dom';
 import { Router } from '../constants/Router';
 

--- a/packages/routing/src/01-basic/index.tsx
+++ b/packages/routing/src/01-basic/index.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { BrowserRouter, generatePath, Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import { Navigation } from './components/Navigation';
 import { Router } from './constants/Router';

--- a/packages/routing/src/01-basic/pages/Friends/Friend.tsx
+++ b/packages/routing/src/01-basic/pages/Friends/Friend.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { useParams } from 'react-router';
 import { getFriendById } from '../Friends';
 

--- a/packages/routing/src/01-basic/pages/Friends/index.tsx
+++ b/packages/routing/src/01-basic/pages/Friends/index.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { generatePath, Link, Outlet } from 'react-router-dom';
 import { Router } from '../../constants/Router';
 

--- a/packages/routing/src/02-nest-routes-deep/components/Navigation.tsx
+++ b/packages/routing/src/02-nest-routes-deep/components/Navigation.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { Link } from 'react-router-dom';
 import { Router } from '../constants/Router';
 

--- a/packages/routing/src/02-nest-routes-deep/index.tsx
+++ b/packages/routing/src/02-nest-routes-deep/index.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { ReactNode } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Navigation } from './components/Navigation';

--- a/packages/routing/src/02-nest-routes-deep/pages/Friends/Friend.tsx
+++ b/packages/routing/src/02-nest-routes-deep/pages/Friends/Friend.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { useParams } from 'react-router';
 import { getFriendById } from '.';
 

--- a/packages/routing/src/02-nest-routes-deep/pages/Friends/index.tsx
+++ b/packages/routing/src/02-nest-routes-deep/pages/Friends/index.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { generatePath, Navigate, NavLink, Route, Routes } from 'react-router-dom';
 import { Router } from '../../constants/Router';
 import { Friend } from './Friend';

--- a/packages/routing/src/03-route-objects/components/Navigation.tsx
+++ b/packages/routing/src/03-route-objects/components/Navigation.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { Link } from 'react-router-dom';
 
 export const Navigation = () => (

--- a/packages/routing/src/03-route-objects/index.tsx
+++ b/packages/routing/src/03-route-objects/index.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { RouteObject } from 'react-router-dom';
 import { BrowserRouter, Outlet, useRoutes } from 'react-router-dom';
 import { Navigation } from './components/Navigation';

--- a/packages/routing/src/03-route-objects/pages/Friends/Friend.tsx
+++ b/packages/routing/src/03-route-objects/pages/Friends/Friend.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { useParams } from 'react-router';
 import { getFriendById } from '.';
 

--- a/packages/routing/src/03-route-objects/pages/Friends/index.tsx
+++ b/packages/routing/src/03-route-objects/pages/Friends/index.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { RouteObject } from 'react-router-dom';
 import { Link, Navigate, useRoutes } from 'react-router-dom';
 import { Friend } from './Friend';

--- a/packages/routing/src/04-with-page-transition/components/Navigation.tsx
+++ b/packages/routing/src/04-with-page-transition/components/Navigation.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { Link } from 'react-router-dom';
 import { Router } from '../constants/Router';
 

--- a/packages/routing/src/04-with-page-transition/index.tsx
+++ b/packages/routing/src/04-with-page-transition/index.tsx
@@ -1,7 +1,7 @@
-import { css } from '@emotion/css';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { withSuspense } from '@learn-react/core/helpers/Component';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { ReactNode } from 'react';
 import { lazy } from 'react';
 import { BrowserRouter, Route } from 'react-router-dom';

--- a/packages/routing/src/04-with-page-transition/pages/Stones/Member.tsx
+++ b/packages/routing/src/04-with-page-transition/pages/Stones/Member.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { useParams } from 'react-router';
 import { getMemberById } from '.';
 

--- a/packages/routing/src/04-with-page-transition/pages/Stones/index.tsx
+++ b/packages/routing/src/04-with-page-transition/pages/Stones/index.tsx
@@ -1,7 +1,7 @@
-import { css } from '@emotion/css';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { withSuspense } from '@learn-react/core/helpers/Component';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { lazy } from 'react';
 import { generatePath, Navigate, NavLink, Route } from 'react-router-dom';
 import { Router } from '../../constants/Router';

--- a/packages/routing/src/index.tsx
+++ b/packages/routing/src/index.tsx
@@ -1,8 +1,8 @@
-import { css } from '@emotion/css';
 import { LineHeight } from '@learn-react/core/constants/Style';
 import { createContainer } from '@learn-react/core/helpers/Container';
 import { StorageProxy } from '@learn-react/core/helpers/Storage';
 import { applyGlobalStyle, applyResetStyle, gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { ChangeEvent, FC } from 'react';
 import { StrictMode, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/packages/statement/src/21-mobx-basic/bootstraps/App.tsx
+++ b/packages/statement/src/21-mobx-basic/bootstraps/App.tsx
@@ -1,7 +1,7 @@
-import { css } from '@emotion/css';
 import { Sidebar } from '@learn-react/core/components/navigation/Sidebar';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { ComponentProps } from 'react';
 import { Route } from 'react-router-dom';
 import { Router } from '../../@core/constants/Router';

--- a/packages/statement/src/21-mobx-basic/pages/ListPage.tsx
+++ b/packages/statement/src/21-mobx-basic/pages/ListPage.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { observer } from 'mobx-react';
 import type { ChangeEvent } from 'react';
 import { createContext, useMemo, useState } from 'react';

--- a/packages/statement/src/22-mobx-hooks/bootstraps/App.tsx
+++ b/packages/statement/src/22-mobx-hooks/bootstraps/App.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import { Sidebar } from '@learn-react/core/components/navigation/Sidebar';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
+import { css } from '@linaria/core';
 import type { ComponentProps } from 'react';
 import { Route } from 'react-router-dom';
 import { Router } from '../../@core/constants/Router';

--- a/packages/statement/src/22-mobx-hooks/pages/ListPage.tsx
+++ b/packages/statement/src/22-mobx-hooks/pages/ListPage.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { toJS } from 'mobx';
 import { observer } from 'mobx-react';
 import type { ChangeEvent } from 'react';

--- a/packages/statement/src/22-mobx-hooks/pages/Users/components/Log.tsx
+++ b/packages/statement/src/22-mobx-hooks/pages/Users/components/Log.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import { LineHeight } from '@learn-react/core/constants/Style';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { observer } from 'mobx-react';
 import { UsersStore } from '../stores/UsersStore';
 

--- a/packages/statement/src/22-mobx-hooks/pages/Users/index.tsx
+++ b/packages/statement/src/22-mobx-hooks/pages/Users/index.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { useState } from 'react';
 import { GetByParamForm } from './components/GetByParamForm';
 import { GetForm } from './components/GetForm';

--- a/packages/statement/src/31-unstated-basic/bootstraps/App.tsx
+++ b/packages/statement/src/31-unstated-basic/bootstraps/App.tsx
@@ -1,7 +1,7 @@
-import { css } from '@emotion/css';
 import { Sidebar } from '@learn-react/core/components/navigation/Sidebar';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { ComponentProps } from 'react';
 import { Route } from 'react-router-dom';
 import { Router } from '../../@core/constants/Router';

--- a/packages/statement/src/31-unstated-basic/pages/ListPage.tsx
+++ b/packages/statement/src/31-unstated-basic/pages/ListPage.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 import { ListContainer } from '../containers/ListContainer';

--- a/packages/statement/src/31-unstated-basic/pages/profiles/index.tsx
+++ b/packages/statement/src/31-unstated-basic/pages/profiles/index.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { Navigate, Route } from 'react-router-dom';
 import { Router } from '../../../@core/constants/Router';
 import { ProfileContainer } from '../../containers/ProfileContainer';

--- a/packages/statement/src/41-constate-basic/bootstraps/App.tsx
+++ b/packages/statement/src/41-constate-basic/bootstraps/App.tsx
@@ -1,7 +1,7 @@
-import { css } from '@emotion/css';
 import { Sidebar } from '@learn-react/core/components/navigation/Sidebar';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { ComponentProps } from 'react';
 import { Route } from 'react-router-dom';
 import { Router } from '../../@core/constants/Router';

--- a/packages/statement/src/41-constate-basic/pages/ListPage.tsx
+++ b/packages/statement/src/41-constate-basic/pages/ListPage.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 import { ListProvider, useAddListItem, useEditListItem, useListItems } from '../containers/ListContainer';

--- a/packages/statement/src/41-constate-basic/pages/profiles/index.tsx
+++ b/packages/statement/src/41-constate-basic/pages/profiles/index.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { Navigate, Route } from 'react-router-dom';
 import { Router } from '../../../@core/constants/Router';
 import { ProfileContainer } from '../../containers/ProfileContainer';

--- a/packages/statement/src/App.tsx
+++ b/packages/statement/src/App.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import { StorageProxy } from '@learn-react/core/helpers/Storage';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { ChangeEvent, FC } from 'react';
 import { useEffect, useState } from 'react';
 import { MobxHooksApp } from './22-mobx-hooks';

--- a/packages/try/src/Bubbling/index.story.tsx
+++ b/packages/try/src/Bubbling/index.story.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { MouseEvent } from 'react';
 
 export const Story = () => {

--- a/packages/try/src/Suspense2/index.story.tsx
+++ b/packages/try/src/Suspense2/index.story.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 import { DataFetching1 } from './DataFetching1';

--- a/packages/try/src/Transition2/1_Prepare.story.tsx
+++ b/packages/try/src/Transition2/1_Prepare.story.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { Issues } from './common/Issues';
 import { usePageNumberV1 } from './common/usePageNumber';
 

--- a/packages/try/src/Transition2/2_WithSuspense.story.tsx
+++ b/packages/try/src/Transition2/2_WithSuspense.story.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { Suspense } from 'react';
 import { Issues } from './common/Issues';
 import { usePageNumberV1 } from './common/usePageNumber';

--- a/packages/try/src/Transition2/3_WithTransition.story.tsx
+++ b/packages/try/src/Transition2/3_WithTransition.story.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { Suspense } from 'react';
 import { Issues } from './common/Issues';
 import { usePageNumberV2 } from './common/usePageNumber';

--- a/packages/try/src/Transition2/4_WithLoadable.story.tsx
+++ b/packages/try/src/Transition2/4_WithLoadable.story.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import { FontSize } from '@learn-react/core/constants/Style';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import { Suspense } from 'react';
 import type { IssueType } from './common/Api';
 import { fetchIssues, useData } from './common/Api';

--- a/packages/try/src/Transition2/common/Issues.tsx
+++ b/packages/try/src/Transition2/common/Issues.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
 import { FontSize } from '@learn-react/core/constants/Style';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
+import { css } from '@linaria/core';
 import useSWR from 'swr';
 
 type IssueType = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.20.0, @babel/compat-data@npm:^7.20.1":
+  version: 7.20.1
+  resolution: "@babel/compat-data@npm:7.20.1"
+  checksum: 989b9b7a6fe43c547bb8329241bd0ba6983488b83d29cc59de35536272ee6bb4cc7487ba6c8a4bceebb3a57f8c5fea1434f80bbbe75202bc79bc1110f955ff25
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.19.3":
   version: 7.19.4
   resolution: "@babel/compat-data@npm:7.19.4"
@@ -54,6 +61,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.18.2":
+  version: 7.20.2
+  resolution: "@babel/core@npm:7.20.2"
+  dependencies:
+    "@ampproject/remapping": ^2.1.0
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.20.2
+    "@babel/helper-compilation-targets": ^7.20.0
+    "@babel/helper-module-transforms": ^7.20.2
+    "@babel/helpers": ^7.20.1
+    "@babel/parser": ^7.20.2
+    "@babel/template": ^7.18.10
+    "@babel/traverse": ^7.20.1
+    "@babel/types": ^7.20.2
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.2.1
+    semver: ^6.3.0
+  checksum: 98faaaef26103a276a30a141b951a93bc8418d100d1f668bf7a69d12f3e25df57958e8b6b9100d95663f720db62da85ade736f6629a5ebb1e640251a1b43c0e4
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:^7.19.6":
   version: 7.19.6
   resolution: "@babel/core@npm:7.19.6"
@@ -74,6 +104,17 @@ __metadata:
     json5: ^2.2.1
     semver: ^6.3.0
   checksum: 85c0bd38d0ef180aa2d23c3db6840a0baec88d2e05c30e7ffc3dfeb6b2b89d6e4864922f04997a1f4ce55f9dd469bf2e76518d5c7ae744b98516709d32769b73
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:>=7, @babel/generator@npm:^7.20.1, @babel/generator@npm:^7.20.2":
+  version: 7.20.4
+  resolution: "@babel/generator@npm:7.20.4"
+  dependencies:
+    "@babel/types": ^7.20.2
+    "@jridgewell/gen-mapping": ^0.3.2
+    jsesc: ^2.5.1
+  checksum: 967b59f18e5ce999e5a741825bcecb2be4bbfc1824a92c21b47d0b5694e0eb09314a70f8b9142e9591c149c7fb83d51f73ae8fbd96d30a42666425889e51ceb1
   languageName: node
   linkType: hard
 
@@ -108,6 +149,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-builder-binary-assignment-operator-visitor@npm:^7.18.6":
+  version: 7.18.9
+  resolution: "@babel/helper-builder-binary-assignment-operator-visitor@npm:7.18.9"
+  dependencies:
+    "@babel/helper-explode-assignable-expression": ^7.18.6
+    "@babel/types": ^7.18.9
+  checksum: b4bc214cb56329daff6cc18a7f7a26aeafb55a1242e5362f3d47fe3808421f8c7cd91fff95d6b9b7ccb67e14e5a67d944e49dbe026942bfcbfda19b1c72a8e72
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.17.7, @babel/helper-compilation-targets@npm:^7.18.9, @babel/helper-compilation-targets@npm:^7.20.0":
+  version: 7.20.0
+  resolution: "@babel/helper-compilation-targets@npm:7.20.0"
+  dependencies:
+    "@babel/compat-data": ^7.20.0
+    "@babel/helper-validator-option": ^7.18.6
+    browserslist: ^4.21.3
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: bc183f2109648849c8fde0b3c5cf08adf2f7ad6dc617b546fd20f34c8ef574ee5ee293c8d1bd0ed0221212e8f5907cdc2c42097870f1dcc769a654107d82c95b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-compilation-targets@npm:^7.19.3":
   version: 7.19.3
   resolution: "@babel/helper-compilation-targets@npm:7.19.3"
@@ -122,6 +187,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.20.2":
+  version: 7.20.2
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.20.2"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.18.6
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-member-expression-to-functions": ^7.18.9
+    "@babel/helper-optimise-call-expression": ^7.18.6
+    "@babel/helper-replace-supers": ^7.19.1
+    "@babel/helper-split-export-declaration": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: e89a8841db3f6340996f395fc372ee4bec361230eb9345b763314f768e68421d43461918fdedfb9a69b71f1d0433439f3e318d1b1b9ba04fbd7aac1c84959e37
+  languageName: node
+  linkType: hard
+
+"@babel/helper-create-regexp-features-plugin@npm:^7.18.6, @babel/helper-create-regexp-features-plugin@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.19.0"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.18.6
+    regexpu-core: ^5.1.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 811cc90afe9fc25a74ed37fc0c1361a4a91b0b940235dd3958e3f03b366d40a903b40fc93b51bcb93be774aba573219f8f215664bea1d1301f58797ca6854f3f
+  languageName: node
+  linkType: hard
+
+"@babel/helper-define-polyfill-provider@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "@babel/helper-define-polyfill-provider@npm:0.3.3"
+  dependencies:
+    "@babel/helper-compilation-targets": ^7.17.7
+    "@babel/helper-plugin-utils": ^7.16.7
+    debug: ^4.1.1
+    lodash.debounce: ^4.0.8
+    resolve: ^1.14.2
+    semver: ^6.1.2
+  peerDependencies:
+    "@babel/core": ^7.4.0-0
+  checksum: 8e3fe75513302e34f6d92bd67b53890e8545e6c5bca8fe757b9979f09d68d7e259f6daea90dc9e01e332c4f8781bda31c5fe551c82a277f9bc0bec007aed497c
+  languageName: node
+  linkType: hard
+
 "@babel/helper-environment-visitor@npm:^7.18.9":
   version: 7.18.9
   resolution: "@babel/helper-environment-visitor@npm:7.18.9"
@@ -129,7 +239,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-function-name@npm:^7.19.0":
+"@babel/helper-explode-assignable-expression@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-explode-assignable-expression@npm:7.18.6"
+  dependencies:
+    "@babel/types": ^7.18.6
+  checksum: 225cfcc3376a8799023d15dc95000609e9d4e7547b29528c7f7111a0e05493ffb12c15d70d379a0bb32d42752f340233c4115bded6d299bc0c3ab7a12be3d30f
+  languageName: node
+  linkType: hard
+
+"@babel/helper-function-name@npm:^7.18.9, @babel/helper-function-name@npm:^7.19.0":
   version: 7.19.0
   resolution: "@babel/helper-function-name@npm:7.19.0"
   dependencies:
@@ -148,12 +267,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.16.7, @babel/helper-module-imports@npm:^7.18.6":
+"@babel/helper-member-expression-to-functions@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.18.9"
+  dependencies:
+    "@babel/types": ^7.18.9
+  checksum: fcf8184e3b55051c4286b2cbedf0eccc781d0f3c9b5cbaba582eca19bf0e8d87806cdb7efc8554fcb969ceaf2b187d5ea748d40022d06ec7739fbb18c1b19a7a
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-module-imports@npm:7.18.6"
   dependencies:
     "@babel/types": ^7.18.6
   checksum: f393f8a3b3304b1b7a288a38c10989de754f01d29caf62ce7c4e5835daf0a27b81f3ac687d9d2780d39685aae7b55267324b512150e7b2be967b0c493b6a1def
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.18.6, @babel/helper-module-transforms@npm:^7.20.2":
+  version: 7.20.2
+  resolution: "@babel/helper-module-transforms@npm:7.20.2"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-module-imports": ^7.18.6
+    "@babel/helper-simple-access": ^7.20.2
+    "@babel/helper-split-export-declaration": ^7.18.6
+    "@babel/helper-validator-identifier": ^7.19.1
+    "@babel/template": ^7.18.10
+    "@babel/traverse": ^7.20.1
+    "@babel/types": ^7.20.2
+  checksum: 33a60ca115f6fce2c9d98e2a2e5649498aa7b23e2ae3c18745d7a021487708fc311458c33542f299387a0da168afccba94116e077f2cce49ae9e5ab83399e8a2
   languageName: node
   linkType: hard
 
@@ -189,10 +333,53 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-optimise-call-expression@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-optimise-call-expression@npm:7.18.6"
+  dependencies:
+    "@babel/types": ^7.18.6
+  checksum: e518fe8418571405e21644cfb39cf694f30b6c47b10b006609a92469ae8b8775cbff56f0b19732343e2ea910641091c5a2dc73b56ceba04e116a33b0f8bd2fbd
+  languageName: node
+  linkType: hard
+
 "@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.19.0, @babel/helper-plugin-utils@npm:^7.8.0":
   version: 7.19.0
   resolution: "@babel/helper-plugin-utils@npm:7.19.0"
   checksum: eedc996c633c8c207921c26ec2989eae0976336ecd9b9f1ac526498f52b5d136f7cd03c32b6fdf8d46a426f907c142de28592f383c42e5fba1e904cbffa05345
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.16.7, @babel/helper-plugin-utils@npm:^7.18.9, @babel/helper-plugin-utils@npm:^7.20.2, @babel/helper-plugin-utils@npm:^7.8.3":
+  version: 7.20.2
+  resolution: "@babel/helper-plugin-utils@npm:7.20.2"
+  checksum: f6cae53b7fdb1bf3abd50fa61b10b4470985b400cc794d92635da1e7077bb19729f626adc0741b69403d9b6e411cddddb9c0157a709cc7c4eeb41e663be5d74b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-remap-async-to-generator@npm:^7.18.6, @babel/helper-remap-async-to-generator@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/helper-remap-async-to-generator@npm:7.18.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.18.6
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-wrap-function": ^7.18.9
+    "@babel/types": ^7.18.9
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 4be6076192308671b046245899b703ba090dbe7ad03e0bea897bb2944ae5b88e5e85853c9d1f83f643474b54c578d8ac0800b80341a86e8538264a725fbbefec
+  languageName: node
+  linkType: hard
+
+"@babel/helper-replace-supers@npm:^7.18.6, @babel/helper-replace-supers@npm:^7.19.1":
+  version: 7.19.1
+  resolution: "@babel/helper-replace-supers@npm:7.19.1"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-member-expression-to-functions": ^7.18.9
+    "@babel/helper-optimise-call-expression": ^7.18.6
+    "@babel/traverse": ^7.19.1
+    "@babel/types": ^7.19.0
+  checksum: a0e4bf79ebe7d2bb5947169e47a0b4439c73fb0ec57d446cf3ea81b736721129ec373c3f94d2ebd2716b26dd65f8e6c083dac898170d42905e7ba815a2f52c25
   languageName: node
   linkType: hard
 
@@ -202,6 +389,24 @@ __metadata:
   dependencies:
     "@babel/types": ^7.19.4
   checksum: 964cb1ec36b69aabbb02f8d5ee1d680ebbb628611a6740958d9b05107ab16c0492044e430618ae42b1f8ea73e4e1bafe3750e8ebc959d6f3277d9cfbe1a94880
+  languageName: node
+  linkType: hard
+
+"@babel/helper-simple-access@npm:^7.20.2":
+  version: 7.20.2
+  resolution: "@babel/helper-simple-access@npm:7.20.2"
+  dependencies:
+    "@babel/types": ^7.20.2
+  checksum: ad1e96ee2e5f654ffee2369a586e5e8d2722bf2d8b028a121b4c33ebae47253f64d420157b9f0a8927aea3a9e0f18c0103e74fdd531815cf3650a0a4adca11a1
+  languageName: node
+  linkType: hard
+
+"@babel/helper-skip-transparent-expression-wrappers@npm:^7.18.9":
+  version: 7.20.0
+  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.20.0"
+  dependencies:
+    "@babel/types": ^7.20.0
+  checksum: 34da8c832d1c8a546e45d5c1d59755459ffe43629436707079989599b91e8c19e50e73af7a4bd09c95402d389266731b0d9c5f69e372d8ebd3a709c05c80d7dd
   languageName: node
   linkType: hard
 
@@ -235,6 +440,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-wrap-function@npm:^7.18.9":
+  version: 7.19.0
+  resolution: "@babel/helper-wrap-function@npm:7.19.0"
+  dependencies:
+    "@babel/helper-function-name": ^7.19.0
+    "@babel/template": ^7.18.10
+    "@babel/traverse": ^7.19.0
+    "@babel/types": ^7.19.0
+  checksum: 2453a6b134f12cc779179188c4358a66252c29b634a8195c0cf626e17f9806c3c4c40e159cd8056c2ec82b69b9056a088014fa43d6ccc1aca67da8d9605da8fd
+  languageName: node
+  linkType: hard
+
 "@babel/helpers@npm:^7.19.0":
   version: 7.19.4
   resolution: "@babel/helpers@npm:7.19.4"
@@ -254,6 +471,17 @@ __metadata:
     "@babel/traverse": ^7.20.0
     "@babel/types": ^7.20.0
   checksum: a68f271474eabc06d64db3d22f435068c3451ba55828f22b72db0e392dff911a6813de3c7bb783e6e4756fd97f8910904d6d647de92a3dc3bfae14688a1a907a
+  languageName: node
+  linkType: hard
+
+"@babel/helpers@npm:^7.20.1":
+  version: 7.20.1
+  resolution: "@babel/helpers@npm:7.20.1"
+  dependencies:
+    "@babel/template": ^7.18.10
+    "@babel/traverse": ^7.20.1
+    "@babel/types": ^7.20.0
+  checksum: be35f78666bdab895775ed94dbeb098f7b4fa08ce4cfb0c3a9e69b7220cce56960dcdc2b14f5df9d3b80388d4bf7df155c97f6cf6768c0138f4e6931d0f44955
   languageName: node
   linkType: hard
 
@@ -286,6 +514,228 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.20.1, @babel/parser@npm:^7.20.2":
+  version: 7.20.3
+  resolution: "@babel/parser@npm:7.20.3"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 33bcdb45de65a3cf27ed376cb34f32be3c3485a10e3252f8d0126f6a034efc3145c0d219e57fcd5a8956361552008bc30b9bae4a723823fb3633027071be8a45
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 845bd280c55a6a91d232cfa54eaf9708ec71e594676fe705794f494bb8b711d833b752b59d1a5c154695225880c23dbc9cab0e53af16fd57807976cd3ff41b8d
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.18.9
+    "@babel/plugin-proposal-optional-chaining": ^7.18.9
+  peerDependencies:
+    "@babel/core": ^7.13.0
+  checksum: 93abb5cb179a13db171bfc2cdf79489598f43c50cc174f97a2b7bb1d44d24ade7109665a20cf4e317ad6c1c730f036f06478f7c7e789b4240be1abdb60d6452f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-async-generator-functions@npm:^7.20.1":
+  version: 7.20.1
+  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.20.1"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-plugin-utils": ^7.19.0
+    "@babel/helper-remap-async-to-generator": ^7.18.9
+    "@babel/plugin-syntax-async-generators": ^7.8.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 518483a68c5618932109913eb7316ed5e656c575cbd9d22667bc0451e35a1be45f8eaeb8e2065834b36c8a93c4840f78cebf8f1d067b07c422f7be16d58eca60
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-class-properties@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-class-properties@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 49a78a2773ec0db56e915d9797e44fd079ab8a9b2e1716e0df07c92532f2c65d76aeda9543883916b8e0ff13606afeffa67c5b93d05b607bc87653ad18a91422
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-class-static-block@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-class-static-block@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/plugin-syntax-class-static-block": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.12.0
+  checksum: b8d7ae99ed5ad784f39e7820e3ac03841f91d6ed60ab4a98c61d6112253da36013e12807bae4ffed0ef3cb318e47debac112ed614e03b403fb8b075b09a828ee
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-dynamic-import@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-dynamic-import@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 96b1c8a8ad8171d39e9ab106be33bde37ae09b22fb2c449afee9a5edf3c537933d79d963dcdc2694d10677cb96da739cdf1b53454e6a5deab9801f28a818bb2f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-export-namespace-from@npm:>=7, @babel/plugin-proposal-export-namespace-from@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-proposal-export-namespace-from@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 84ff22bacc5d30918a849bfb7e0e90ae4c5b8d8b65f2ac881803d1cf9068dffbe53bd657b0e4bc4c20b4db301b1c85f1e74183cf29a0dd31e964bd4e97c363ef
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-json-strings@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-json-strings@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/plugin-syntax-json-strings": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 25ba0e6b9d6115174f51f7c6787e96214c90dd4026e266976b248a2ed417fe50fddae72843ffb3cbe324014a18632ce5648dfac77f089da858022b49fd608cb3
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-logical-assignment-operators@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-proposal-logical-assignment-operators@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: dd87fa4a48c6408c5e85dbd6405a65cc8fe909e3090030df46df90df64cdf3e74007381a58ed87608778ee597eff7395d215274009bb3f5d8964b2db5557754f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-nullish-coalescing-operator@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-nullish-coalescing-operator@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 949c9ddcdecdaec766ee610ef98f965f928ccc0361dd87cf9f88cf4896a6ccd62fce063d4494778e50da99dea63d270a1be574a62d6ab81cbe9d85884bf55a7d
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-numeric-separator@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-numeric-separator@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/plugin-syntax-numeric-separator": ^7.10.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: f370ea584c55bf4040e1f78c80b4eeb1ce2e6aaa74f87d1a48266493c33931d0b6222d8cee3a082383d6bb648ab8d6b7147a06f974d3296ef3bc39c7851683ec
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-object-rest-spread@npm:^7.20.2":
+  version: 7.20.2
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.20.2"
+  dependencies:
+    "@babel/compat-data": ^7.20.1
+    "@babel/helper-compilation-targets": ^7.20.0
+    "@babel/helper-plugin-utils": ^7.20.2
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
+    "@babel/plugin-transform-parameters": ^7.20.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 9764d1a4735fcd384fdb9b6c6ccb20d1bea2f88f648640d26ce5d9cd5880ce1e389d2f852d7bea7e86ff343726225dc16e1deb92c7b3dc5c5721ed905a602318
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-optional-catch-binding@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-optional-catch-binding@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7b5b39fb5d8d6d14faad6cb68ece5eeb2fd550fb66b5af7d7582402f974f5bc3684641f7c192a5a57e0f59acfae4aada6786be1eba030881ddc590666eff4d1e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-optional-chaining@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-proposal-optional-chaining@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.18.9
+    "@babel/plugin-syntax-optional-chaining": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: f2db40e26172f07c50b635cb61e1f36165de3ba868fcf608d967642f0d044b7c6beb0e7ecf17cbd421144b99e1eae7ad6031ded92925343bb0ed1d08707b514f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-private-methods@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-private-methods@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 22d8502ee96bca99ad2c8393e8493e2b8d4507576dd054490fd8201a36824373440106f5b098b6d821b026c7e72b0424ff4aeca69ed5f42e48f029d3a156d5ad
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-private-property-in-object@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.18.6"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.18.6
+    "@babel/helper-create-class-features-plugin": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: c8e56a972930730345f39f2384916fd8e711b3f4b4eae2ca9740e99958980118120d5cc9b6ac150f0965a5a35f825910e2c3013d90be3e9993ab6111df444569
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-unicode-property-regex@npm:^7.18.6, @babel/plugin-proposal-unicode-property-regex@npm:^7.4.4":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-unicode-property-regex@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a8575ecb7ff24bf6c6e94808d5c84bb5a0c6dd7892b54f09f4646711ba0ee1e1668032b3c43e3e1dfec2c5716c302e851ac756c1645e15882d73df6ad21ae951
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-syntax-async-generators@npm:^7.8.4":
   version: 7.8.4
   resolution: "@babel/plugin-syntax-async-generators@npm:7.8.4"
@@ -308,7 +758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-class-properties@npm:^7.8.3":
+"@babel/plugin-syntax-class-properties@npm:^7.12.13, @babel/plugin-syntax-class-properties@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-syntax-class-properties@npm:7.12.13"
   dependencies:
@@ -316,6 +766,50 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 24f34b196d6342f28d4bad303612d7ff566ab0a013ce89e775d98d6f832969462e7235f3e7eaf17678a533d4be0ba45d3ae34ab4e5a9dcbda5d98d49e5efa2fc
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-class-static-block@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-syntax-class-static-block@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3e80814b5b6d4fe17826093918680a351c2d34398a914ce6e55d8083d72a9bdde4fbaf6a2dcea0e23a03de26dc2917ae3efd603d27099e2b98380345703bf948
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-dynamic-import@npm:>=7, @babel/plugin-syntax-dynamic-import@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-dynamic-import@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.8.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ce307af83cf433d4ec42932329fad25fa73138ab39c7436882ea28742e1c0066626d224e0ad2988724c82644e41601cef607b36194f695cb78a1fcdc959637bd
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-export-namespace-from@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-export-namespace-from@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 85740478be5b0de185228e7814451d74ab8ce0a26fcca7613955262a26e99e8e15e9da58f60c754b84515d4c679b590dbd3f2148f0f58025f4ae706f1c5a5d4a
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-import-assertions@npm:^7.20.0":
+  version: 7.20.0
+  resolution: "@babel/plugin-syntax-import-assertions@npm:7.20.0"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.19.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6a86220e0aae40164cd3ffaf80e7c076a1be02a8f3480455dddbae05fda8140f429290027604df7a11b3f3f124866e8a6d69dbfa1dda61ee7377b920ad144d5b
   languageName: node
   linkType: hard
 
@@ -341,7 +835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.17.12, @babel/plugin-syntax-jsx@npm:^7.18.6, @babel/plugin-syntax-jsx@npm:^7.7.2":
+"@babel/plugin-syntax-jsx@npm:^7.18.6, @babel/plugin-syntax-jsx@npm:^7.7.2":
   version: 7.18.6
   resolution: "@babel/plugin-syntax-jsx@npm:7.18.6"
   dependencies:
@@ -352,7 +846,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-logical-assignment-operators@npm:^7.8.3":
+"@babel/plugin-syntax-logical-assignment-operators@npm:^7.10.4, @babel/plugin-syntax-logical-assignment-operators@npm:^7.8.3":
   version: 7.10.4
   resolution: "@babel/plugin-syntax-logical-assignment-operators@npm:7.10.4"
   dependencies:
@@ -374,7 +868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-numeric-separator@npm:^7.8.3":
+"@babel/plugin-syntax-numeric-separator@npm:^7.10.4, @babel/plugin-syntax-numeric-separator@npm:^7.8.3":
   version: 7.10.4
   resolution: "@babel/plugin-syntax-numeric-separator@npm:7.10.4"
   dependencies:
@@ -418,7 +912,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-top-level-await@npm:^7.8.3":
+"@babel/plugin-syntax-private-property-in-object@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-syntax-private-property-in-object@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b317174783e6e96029b743ccff2a67d63d38756876e7e5d0ba53a322e38d9ca452c13354a57de1ad476b4c066dbae699e0ca157441da611117a47af88985ecda
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-top-level-await@npm:^7.14.5, @babel/plugin-syntax-top-level-await@npm:^7.8.3":
   version: 7.14.5
   resolution: "@babel/plugin-syntax-top-level-await@npm:7.14.5"
   dependencies:
@@ -426,6 +931,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: bbd1a56b095be7820029b209677b194db9b1d26691fe999856462e66b25b281f031f3dfd91b1619e9dcf95bebe336211833b854d0fb8780d618e35667c2d0d7e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-typescript@npm:^7.20.0":
+  version: 7.20.0
+  resolution: "@babel/plugin-syntax-typescript@npm:7.20.0"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.19.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6189c0b5c32ba3c9a80a42338bd50719d783b20ef29b853d4f03929e971913d3cefd80184e924ae98ad6db09080be8fe6f1ffde9a6db8972523234f0274d36f7
   languageName: node
   linkType: hard
 
@@ -437,6 +953,282 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2cde73725ec51118ebf410bf02d78781c03fa4d3185993fcc9d253b97443381b621c44810084c5dd68b92eb8bdfae0e5b163e91b32bebbb33852383d1815c05d
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-arrow-functions@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-arrow-functions@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 900f5c695755062b91eec74da6f9092f40b8fada099058b92576f1e23c55e9813ec437051893a9b3c05cefe39e8ac06303d4a91b384e1c03dd8dc1581ea11602
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-async-to-generator@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-async-to-generator@npm:7.18.6"
+  dependencies:
+    "@babel/helper-module-imports": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/helper-remap-async-to-generator": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: c2cca47468cf1aeefdc7ec35d670e195c86cee4de28a1970648c46a88ce6bd1806ef0bab27251b9e7fb791bb28a64dcd543770efd899f28ee5f7854e64e873d3
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-block-scoped-functions@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-block-scoped-functions@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0a0df61f94601e3666bf39f2cc26f5f7b22a94450fb93081edbed967bd752ce3f81d1227fefd3799f5ee2722171b5e28db61379234d1bb85b6ec689589f99d7e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-block-scoping@npm:^7.20.2":
+  version: 7.20.2
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.20.2"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.20.2
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 550b983277557ecfa3ef1e7a2367eaa9e0616a56f0d4106812cbc8aeca057b0f0b8bbc5c548b9b3b57399868f916e89e17303c802c8c46d18fba5bc174d4e794
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-classes@npm:^7.20.2":
+  version: 7.20.2
+  resolution: "@babel/plugin-transform-classes@npm:7.20.2"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.18.6
+    "@babel/helper-compilation-targets": ^7.20.0
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-optimise-call-expression": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.20.2
+    "@babel/helper-replace-supers": ^7.19.1
+    "@babel/helper-split-export-declaration": ^7.18.6
+    globals: ^11.1.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 57f3467a8eb7853cdb61cda963cfb6c6568ad276d77c9de2ff5a2194650010217aa318ef3733975537c6fb906b73a019afb6ea650b01852e7d2e1fab4034361b
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-computed-properties@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-computed-properties@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a6bfbea207827d77592628973c0e8cc3319db636506bdc6e81e21582de2e767890e6975b382d0511e9ec3773b9f43691185df90832883bbf9251f688d27fbc1d
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-destructuring@npm:^7.20.2":
+  version: 7.20.2
+  resolution: "@babel/plugin-transform-destructuring@npm:7.20.2"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.20.2
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 09033e09b28ca1b0d46a8d82f5a677b1d718a739b3c199886908c3ef1af23369317d0c429b21507d480ee82721c15892a9893be18e50ad6fc219e69312f4b097
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-dotall-regex@npm:^7.18.6, @babel/plugin-transform-dotall-regex@npm:^7.4.4":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-dotall-regex@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: cbe5d7063eb8f8cca24cd4827bc97f5641166509e58781a5f8aa47fb3d2d786ce4506a30fca2e01f61f18792783a5cb5d96bf5434c3dd1ad0de8c9cc625a53da
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-duplicate-keys@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-duplicate-keys@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 220bf4a9fec5c4d4a7b1de38810350260e8ea08481bf78332a464a21256a95f0df8cd56025f346238f09b04f8e86d4158fafc9f4af57abaef31637e3b58bd4fe
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-exponentiation-operator@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.18.6"
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7f70222f6829c82a36005508d34ddbe6fd0974ae190683a8670dd6ff08669aaf51fef2209d7403f9bd543cb2d12b18458016c99a6ed0332ccedb3ea127b01229
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-for-of@npm:^7.18.8":
+  version: 7.18.8
+  resolution: "@babel/plugin-transform-for-of@npm:7.18.8"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ca64c623cf0c7a80ab6f07ebd3e6e4ade95e2ae806696f70b43eafe6394fa8ce21f2b1ffdd15df2067f7363d2ecfe26472a97c6c774403d2163fa05f50c98f17
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-function-name@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-function-name@npm:7.18.9"
+  dependencies:
+    "@babel/helper-compilation-targets": ^7.18.9
+    "@babel/helper-function-name": ^7.18.9
+    "@babel/helper-plugin-utils": ^7.18.9
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 62dd9c6cdc9714704efe15545e782ee52d74dc73916bf954b4d3bee088fb0ec9e3c8f52e751252433656c09f744b27b757fc06ed99bcde28e8a21600a1d8e597
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-literals@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-literals@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3458dd2f1a47ac51d9d607aa18f3d321cbfa8560a985199185bed5a906bb0c61ba85575d386460bac9aed43fdd98940041fae5a67dff286f6f967707cff489f8
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-member-expression-literals@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-member-expression-literals@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 35a3d04f6693bc6b298c05453d85ee6e41cc806538acb6928427e0e97ae06059f97d2f07d21495fcf5f70d3c13a242e2ecbd09d5c1fcb1b1a73ff528dcb0b695
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-amd@npm:^7.19.6":
+  version: 7.19.6
+  resolution: "@babel/plugin-transform-modules-amd@npm:7.19.6"
+  dependencies:
+    "@babel/helper-module-transforms": ^7.19.6
+    "@babel/helper-plugin-utils": ^7.19.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 4236aad970025bc10c772c1589b1e2eab8b7681933bb5ffa6e395d4c1a52532b28c47c553e3011b4272ea81e5ab39fe969eb5349584e8390e59771055c467d42
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-commonjs@npm:^7.18.2, @babel/plugin-transform-modules-commonjs@npm:^7.19.6":
+  version: 7.19.6
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.19.6"
+  dependencies:
+    "@babel/helper-module-transforms": ^7.19.6
+    "@babel/helper-plugin-utils": ^7.19.0
+    "@babel/helper-simple-access": ^7.19.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 85d46945ab5ba3fff89e962d560a5d40253f228b9659a697683db3de07c0236e8cd60e5eb41958007359951a42bc268bf32350fcdb5b4a86f58dff1e032c096e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-systemjs@npm:^7.19.6":
+  version: 7.19.6
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.19.6"
+  dependencies:
+    "@babel/helper-hoist-variables": ^7.18.6
+    "@babel/helper-module-transforms": ^7.19.6
+    "@babel/helper-plugin-utils": ^7.19.0
+    "@babel/helper-validator-identifier": ^7.19.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 8526431cc81ea3eb232ad50862d0ed1cbb422b5251d14a8d6610d0ca0617f6e75f35179e98eb1235d0cccb980120350b9f112594e5646dd45378d41eaaf87342
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-umd@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-modules-umd@npm:7.18.6"
+  dependencies:
+    "@babel/helper-module-transforms": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: c3b6796c6f4579f1ba5ab0cdcc73910c1e9c8e1e773c507c8bb4da33072b3ae5df73c6d68f9126dab6e99c24ea8571e1563f8710d7c421fac1cde1e434c20153
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.19.1":
+  version: 7.19.1
+  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.19.1"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": ^7.19.0
+    "@babel/helper-plugin-utils": ^7.19.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 8a40f5d04f2140c44fe890a5a3fd72abc2a88445443ac2bd92e1e85d9366d3eb8f1ebb7e2c89d2daeaf213d9b28cb65605502ac9b155936d48045eeda6053494
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-new-target@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-new-target@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: bd780e14f46af55d0ae8503b3cb81ca86dcc73ed782f177e74f498fff934754f9e9911df1f8f3bd123777eed7c1c1af4d66abab87c8daae5403e7719a6b845d1
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-object-super@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-object-super@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/helper-replace-supers": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0fcb04e15deea96ae047c21cb403607d49f06b23b4589055993365ebd7a7d7541334f06bf9642e90075e66efce6ebaf1eb0ef066fbbab802d21d714f1aac3aef
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-parameters@npm:^7.20.1":
+  version: 7.20.3
+  resolution: "@babel/plugin-transform-parameters@npm:7.20.3"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.20.2
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 69054c93d744574e06b0244623140718ecba87e1cc34bd5c7bd5824fd4dbef764ac4832046ea1ba5d2c6a2f12e03289555c9f65f0aafae4871f3d740ff61b9ec
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-property-literals@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-property-literals@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 1c16e64de554703f4b547541de2edda6c01346dd3031d4d29e881aa7733785cd26d53611a4ccf5353f4d3e69097bb0111c0a93ace9e683edd94fea28c4484144
   languageName: node
   linkType: hard
 
@@ -488,6 +1280,250 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-regenerator@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-regenerator@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+    regenerator-transform: ^0.15.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 60bd482cb0343c714f85c3e19a13b3b5fa05ee336c079974091c0b35e263307f4e661f4555dff90707a87d5efe19b1d51835db44455405444ac1813e268ad750
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-reserved-words@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-reserved-words@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0738cdc30abdae07c8ec4b233b30c31f68b3ff0eaa40eddb45ae607c066127f5fa99ddad3c0177d8e2832e3a7d3ad115775c62b431ebd6189c40a951b867a80c
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-runtime@npm:>=7":
+  version: 7.19.6
+  resolution: "@babel/plugin-transform-runtime@npm:7.19.6"
+  dependencies:
+    "@babel/helper-module-imports": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.19.0
+    babel-plugin-polyfill-corejs2: ^0.3.3
+    babel-plugin-polyfill-corejs3: ^0.6.0
+    babel-plugin-polyfill-regenerator: ^0.4.1
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ef93efbcbb00dcf4da6dcc55bda698a2a57fca3fb05a6a13e932ecfdb7c1c5d2f0b5b245c1c4faca0318853937caba0d82442f58b7653249f64275d08052fbd8
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-shorthand-properties@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-shorthand-properties@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b8e4e8acc2700d1e0d7d5dbfd4fdfb935651913de6be36e6afb7e739d8f9ca539a5150075a0f9b79c88be25ddf45abb912fe7abf525f0b80f5b9d9860de685d7
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-spread@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/plugin-transform-spread@npm:7.19.0"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.19.0
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.18.9
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: e73a4deb095999185e70b524d0ff4e35df50fcda58299e700a6149a15bbc1a9b369ef1cef384e15a54b3c3ce316cc0f054dbf249dcd0d1ca59f4281dd4df9718
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-sticky-regex@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-sticky-regex@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 68ea18884ae9723443ffa975eb736c8c0d751265859cd3955691253f7fee37d7a0f7efea96c8a062876af49a257a18ea0ed5fea0d95a7b3611ce40f7ee23aee3
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-template-literals@npm:>=7, @babel/plugin-transform-template-literals@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-template-literals@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3d2fcd79b7c345917f69b92a85bdc3ddd68ce2c87dc70c7d61a8373546ccd1f5cb8adc8540b49dfba08e1b82bb7b3bbe23a19efdb2b9c994db2db42906ca9fb2
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-typeof-symbol@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/plugin-transform-typeof-symbol@npm:7.18.9"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: e754e0d8b8a028c52e10c148088606e3f7a9942c57bd648fc0438e5b4868db73c386a5ed47ab6d6f0594aae29ee5ffc2ffc0f7ebee7fae560a066d6dea811cd4
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-typescript@npm:^7.18.6":
+  version: 7.20.2
+  resolution: "@babel/plugin-transform-typescript@npm:7.20.2"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.20.2
+    "@babel/helper-plugin-utils": ^7.20.2
+    "@babel/plugin-syntax-typescript": ^7.20.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 14434eb77cb3c8c4187a055eabdd5ff8b3e90a37ac95ecc7c9007ea8fc5660e0652c445646a2a25836a02d91944e0dc1e8b58ef55b063a901e54a24fdb4168af
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-unicode-escapes@npm:^7.18.10":
+  version: 7.18.10
+  resolution: "@babel/plugin-transform-unicode-escapes@npm:7.18.10"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: f5baca55cb3c11bc08ec589f5f522d85c1ab509b4d11492437e45027d64ae0b22f0907bd1381e8d7f2a436384bb1f9ad89d19277314242c5c2671a0f91d0f9cd
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-unicode-regex@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-transform-unicode-regex@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d9e18d57536a2d317fb0b7c04f8f55347f3cfacb75e636b4c6fa2080ab13a3542771b5120e726b598b815891fc606d1472ac02b749c69fd527b03847f22dc25e
+  languageName: node
+  linkType: hard
+
+"@babel/preset-env@npm:>=7":
+  version: 7.20.2
+  resolution: "@babel/preset-env@npm:7.20.2"
+  dependencies:
+    "@babel/compat-data": ^7.20.1
+    "@babel/helper-compilation-targets": ^7.20.0
+    "@babel/helper-plugin-utils": ^7.20.2
+    "@babel/helper-validator-option": ^7.18.6
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": ^7.18.6
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.18.9
+    "@babel/plugin-proposal-async-generator-functions": ^7.20.1
+    "@babel/plugin-proposal-class-properties": ^7.18.6
+    "@babel/plugin-proposal-class-static-block": ^7.18.6
+    "@babel/plugin-proposal-dynamic-import": ^7.18.6
+    "@babel/plugin-proposal-export-namespace-from": ^7.18.9
+    "@babel/plugin-proposal-json-strings": ^7.18.6
+    "@babel/plugin-proposal-logical-assignment-operators": ^7.18.9
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.18.6
+    "@babel/plugin-proposal-numeric-separator": ^7.18.6
+    "@babel/plugin-proposal-object-rest-spread": ^7.20.2
+    "@babel/plugin-proposal-optional-catch-binding": ^7.18.6
+    "@babel/plugin-proposal-optional-chaining": ^7.18.9
+    "@babel/plugin-proposal-private-methods": ^7.18.6
+    "@babel/plugin-proposal-private-property-in-object": ^7.18.6
+    "@babel/plugin-proposal-unicode-property-regex": ^7.18.6
+    "@babel/plugin-syntax-async-generators": ^7.8.4
+    "@babel/plugin-syntax-class-properties": ^7.12.13
+    "@babel/plugin-syntax-class-static-block": ^7.14.5
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+    "@babel/plugin-syntax-import-assertions": ^7.20.0
+    "@babel/plugin-syntax-json-strings": ^7.8.3
+    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
+    "@babel/plugin-syntax-numeric-separator": ^7.10.4
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
+    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
+    "@babel/plugin-syntax-optional-chaining": ^7.8.3
+    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+    "@babel/plugin-syntax-top-level-await": ^7.14.5
+    "@babel/plugin-transform-arrow-functions": ^7.18.6
+    "@babel/plugin-transform-async-to-generator": ^7.18.6
+    "@babel/plugin-transform-block-scoped-functions": ^7.18.6
+    "@babel/plugin-transform-block-scoping": ^7.20.2
+    "@babel/plugin-transform-classes": ^7.20.2
+    "@babel/plugin-transform-computed-properties": ^7.18.9
+    "@babel/plugin-transform-destructuring": ^7.20.2
+    "@babel/plugin-transform-dotall-regex": ^7.18.6
+    "@babel/plugin-transform-duplicate-keys": ^7.18.9
+    "@babel/plugin-transform-exponentiation-operator": ^7.18.6
+    "@babel/plugin-transform-for-of": ^7.18.8
+    "@babel/plugin-transform-function-name": ^7.18.9
+    "@babel/plugin-transform-literals": ^7.18.9
+    "@babel/plugin-transform-member-expression-literals": ^7.18.6
+    "@babel/plugin-transform-modules-amd": ^7.19.6
+    "@babel/plugin-transform-modules-commonjs": ^7.19.6
+    "@babel/plugin-transform-modules-systemjs": ^7.19.6
+    "@babel/plugin-transform-modules-umd": ^7.18.6
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.19.1
+    "@babel/plugin-transform-new-target": ^7.18.6
+    "@babel/plugin-transform-object-super": ^7.18.6
+    "@babel/plugin-transform-parameters": ^7.20.1
+    "@babel/plugin-transform-property-literals": ^7.18.6
+    "@babel/plugin-transform-regenerator": ^7.18.6
+    "@babel/plugin-transform-reserved-words": ^7.18.6
+    "@babel/plugin-transform-shorthand-properties": ^7.18.6
+    "@babel/plugin-transform-spread": ^7.19.0
+    "@babel/plugin-transform-sticky-regex": ^7.18.6
+    "@babel/plugin-transform-template-literals": ^7.18.9
+    "@babel/plugin-transform-typeof-symbol": ^7.18.9
+    "@babel/plugin-transform-unicode-escapes": ^7.18.10
+    "@babel/plugin-transform-unicode-regex": ^7.18.6
+    "@babel/preset-modules": ^0.1.5
+    "@babel/types": ^7.20.2
+    babel-plugin-polyfill-corejs2: ^0.3.3
+    babel-plugin-polyfill-corejs3: ^0.6.0
+    babel-plugin-polyfill-regenerator: ^0.4.1
+    core-js-compat: ^3.25.1
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ece2d7e9c7789db6116e962b8e1a55eb55c110c44c217f0c8f6ffea4ca234954e66557f7bd019b7affadf7fbb3a53ccc807e93fc935aacd48146234b73b6947e
+  languageName: node
+  linkType: hard
+
+"@babel/preset-modules@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "@babel/preset-modules@npm:0.1.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.0.0
+    "@babel/plugin-proposal-unicode-property-regex": ^7.4.4
+    "@babel/plugin-transform-dotall-regex": ^7.4.4
+    "@babel/types": ^7.4.4
+    esutils: ^2.0.2
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 8430e0e9e9d520b53e22e8c4c6a5a080a12b63af6eabe559c2310b187bd62ae113f3da82ba33e9d1d0f3230930ca702843aae9dd226dec51f7d7114dc1f51c10
+  languageName: node
+  linkType: hard
+
+"@babel/preset-typescript@npm:7.18.6":
+  version: 7.18.6
+  resolution: "@babel/preset-typescript@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/helper-validator-option": ^7.18.6
+    "@babel/plugin-transform-typescript": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7fe0da5103eb72d3cf39cf3e138a794c8cdd19c0b38e3e101507eef519c46a87a0d6d0e8bc9e28a13ea2364001ebe7430b9d75758aab4c3c3a8db9a487b9dc7c
+  languageName: node
+  linkType: hard
+
 "@babel/runtime-corejs3@npm:^7.10.2":
   version: 7.19.4
   resolution: "@babel/runtime-corejs3@npm:7.19.4"
@@ -498,7 +1534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9":
+"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.18.9":
   version: 7.19.4
   resolution: "@babel/runtime@npm:7.19.4"
   dependencies:
@@ -507,7 +1543,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.18.10, @babel/template@npm:^7.3.3":
+"@babel/runtime@npm:^7.8.4":
+  version: 7.20.1
+  resolution: "@babel/runtime@npm:7.20.1"
+  dependencies:
+    regenerator-runtime: ^0.13.10
+  checksum: 00567a333d3357925742a6f5e39394dcc0af6e6029103fe188158bf7ae8b0b3ee3c6c0f68fccc217f0a6cfa455f6be252298baf56b3f5ff37b34313b170cd9f6
+  languageName: node
+  linkType: hard
+
+"@babel/template@npm:>=7, @babel/template@npm:^7.18.10, @babel/template@npm:^7.3.3":
   version: 7.18.10
   resolution: "@babel/template@npm:7.18.10"
   dependencies:
@@ -515,6 +1560,24 @@ __metadata:
     "@babel/parser": ^7.18.10
     "@babel/types": ^7.18.10
   checksum: 93a6aa094af5f355a72bd55f67fa1828a046c70e46f01b1606e6118fa1802b6df535ca06be83cc5a5e834022be95c7b714f0a268b5f20af984465a71e28f1473
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:>=7, @babel/traverse@npm:^7.19.1, @babel/traverse@npm:^7.20.1":
+  version: 7.20.1
+  resolution: "@babel/traverse@npm:7.20.1"
+  dependencies:
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.20.1
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-hoist-variables": ^7.18.6
+    "@babel/helper-split-export-declaration": ^7.18.6
+    "@babel/parser": ^7.20.1
+    "@babel/types": ^7.20.0
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 6696176d574b7ff93466848010bc7e94b250169379ec2a84f1b10da46a7cc2018ea5e3a520c3078487db51e3a4afab9ecff48f25d1dbad8c1319362f4148fb4b
   languageName: node
   linkType: hard
 
@@ -562,6 +1625,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.19.1
     to-fast-properties: ^2.0.0
   checksum: 4032f6407093f80dd4f4764be676f7527d2a5c0381586967cd79683cf8af01cdc16745a381b9cef045f702f0c9b0dffd880d84ee55dad59ba01bd23d5d52a8e0
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.18.9, @babel/types@npm:^7.20.2, @babel/types@npm:^7.4.4":
+  version: 7.20.2
+  resolution: "@babel/types@npm:7.20.2"
+  dependencies:
+    "@babel/helper-string-parser": ^7.19.4
+    "@babel/helper-validator-identifier": ^7.19.1
+    to-fast-properties: ^2.0.0
+  checksum: 57e76e5f21876135f481bfd4010c87f2d38196bb0a2bc60a28d6e55e3afa90cdd9accf164e4cb71bdfb620517fa0a0cb5600cdce36c21d59fdaccfbb899c024c
   languageName: node
   linkType: hard
 
@@ -1156,114 +2230,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/babel-plugin@npm:^11.10.5":
-  version: 11.10.5
-  resolution: "@emotion/babel-plugin@npm:11.10.5"
-  dependencies:
-    "@babel/helper-module-imports": ^7.16.7
-    "@babel/plugin-syntax-jsx": ^7.17.12
-    "@babel/runtime": ^7.18.3
-    "@emotion/hash": ^0.9.0
-    "@emotion/memoize": ^0.8.0
-    "@emotion/serialize": ^1.1.1
-    babel-plugin-macros: ^3.1.0
-    convert-source-map: ^1.5.0
-    escape-string-regexp: ^4.0.0
-    find-root: ^1.1.0
-    source-map: ^0.5.7
-    stylis: 4.1.3
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: e3353499c76c4422d6e900c0dfab73607056d9da86161a3f27c3459c193c4908050c5d252c68fcde231e13f02a9d8e0dc07d260317ae0e5206841e331cc4caae
-  languageName: node
-  linkType: hard
-
-"@emotion/cache@npm:^11.10.5":
-  version: 11.10.5
-  resolution: "@emotion/cache@npm:11.10.5"
-  dependencies:
-    "@emotion/memoize": ^0.8.0
-    "@emotion/sheet": ^1.2.1
-    "@emotion/utils": ^1.2.0
-    "@emotion/weak-memoize": ^0.3.0
-    stylis: 4.1.3
-  checksum: 1dd2d9af2d3ecbd3d4469ecdf91a335eef6034c851b57a474471b2d2280613eb35bbed98c0368cc4625f188619fbdaf04cf07e8107aaffce94b2178444c0fe7b
-  languageName: node
-  linkType: hard
-
-"@emotion/css@npm:11.10.5":
-  version: 11.10.5
-  resolution: "@emotion/css@npm:11.10.5"
-  dependencies:
-    "@emotion/babel-plugin": ^11.10.5
-    "@emotion/cache": ^11.10.5
-    "@emotion/serialize": ^1.1.1
-    "@emotion/sheet": ^1.2.1
-    "@emotion/utils": ^1.2.0
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
-  checksum: 2f1e953c3519cd69e40d2931cf36c3f1daf33d9f5064cb2612071bd316e38c8debb83d9520db5694ac323b6475f86004f6542919746f005fea0c14a855fc579b
-  languageName: node
-  linkType: hard
-
-"@emotion/hash@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "@emotion/hash@npm:0.9.0"
-  checksum: b63428f7c8186607acdca5d003700cecf0ded519d0b5c5cc3b3154eafcad6ff433f8361bd2bac8882715b557e6f06945694aeb6ba8b25c6095d7a88570e2e0bb
-  languageName: node
-  linkType: hard
-
-"@emotion/memoize@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "@emotion/memoize@npm:0.8.0"
-  checksum: c87bb110b829edd8e1c13b90a6bc37cebc39af29c7599a1e66a48e06f9bec43e8e53495ba86278cc52e7589549492c8dfdc81d19f4fdec0cee6ba13d2ad2c928
-  languageName: node
-  linkType: hard
-
-"@emotion/serialize@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@emotion/serialize@npm:1.1.1"
-  dependencies:
-    "@emotion/hash": ^0.9.0
-    "@emotion/memoize": ^0.8.0
-    "@emotion/unitless": ^0.8.0
-    "@emotion/utils": ^1.2.0
-    csstype: ^3.0.2
-  checksum: 24cfd5b16e6f2335c032ca33804a876e0442aaf8f9c94d269d23735ebd194fb1ed142542dd92191a3e6ef8bad5bd560dfc5aaf363a1b70954726dbd4dd93085c
-  languageName: node
-  linkType: hard
-
-"@emotion/sheet@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@emotion/sheet@npm:1.2.1"
-  checksum: ce78763588ea522438156344d9f592203e2da582d8d67b32e1b0b98eaba26994c6c270f8c7ad46442fc9c0a9f048685d819cd73ca87e544520fd06f0e24a1562
-  languageName: node
-  linkType: hard
-
-"@emotion/unitless@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "@emotion/unitless@npm:0.8.0"
-  checksum: 176141117ed23c0eb6e53a054a69c63e17ae532ec4210907a20b2208f91771821835f1c63dd2ec63e30e22fcc984026d7f933773ee6526dd038e0850919fae7a
-  languageName: node
-  linkType: hard
-
-"@emotion/utils@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@emotion/utils@npm:1.2.0"
-  checksum: 55457a49ddd4db6a014ea0454dc09eaa23eedfb837095c8ff90470cb26a303f7ceb5fcc1e2190ef64683e64cfd33d3ba3ca3109cd87d12bc9e379e4195c9a4dd
-  languageName: node
-  linkType: hard
-
-"@emotion/weak-memoize@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@emotion/weak-memoize@npm:0.3.0"
-  checksum: f43ef4c8b7de70d9fa5eb3105921724651e4188e895beb71f0c5919dc899a7b8743e1fdd99d38b9092dd5722c7be2312ebb47fbdad0c4e38bea58f6df5885cc0
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-arm@npm:0.15.11":
   version: 0.15.11
   resolution: "@esbuild/android-arm@npm:0.15.11"
@@ -1723,6 +2689,102 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@linaria/babel-preset@npm:^3.0.0-beta.23":
+  version: 3.0.0-beta.23
+  resolution: "@linaria/babel-preset@npm:3.0.0-beta.23"
+  dependencies:
+    "@babel/core": ^7.18.2
+    "@babel/generator": ">=7"
+    "@babel/plugin-proposal-export-namespace-from": ">=7"
+    "@babel/plugin-syntax-dynamic-import": ">=7"
+    "@babel/plugin-transform-modules-commonjs": ^7.18.2
+    "@babel/template": ">=7"
+    "@babel/traverse": ">=7"
+    "@linaria/core": ^3.0.0-beta.22
+    "@linaria/logger": ^3.0.0-beta.20
+    "@linaria/utils": ^3.0.0-beta.20
+    cosmiconfig: ^5.1.0
+    find-up: ^5.0.0
+    source-map: ^0.7.3
+    stylis: ^3.5.4
+  checksum: 5e1b7d077272ca93105631b0f9e1d78632769c63fd06d14994ae2b20519e470c2b7170cf50d8a32945e2298afb30f406284a6b46d8abf91b1d9772a55b761385
+  languageName: node
+  linkType: hard
+
+"@linaria/core@npm:3.0.0-beta.22, @linaria/core@npm:^3.0.0-beta.22":
+  version: 3.0.0-beta.22
+  resolution: "@linaria/core@npm:3.0.0-beta.22"
+  dependencies:
+    "@linaria/logger": ^3.0.0-beta.20
+    "@linaria/utils": ^3.0.0-beta.20
+  checksum: 67f57811c78821eb4866e3f307078e3c1cf375ca84f23b4a25cf7f4c34b48b76eaef70a4320436a51145a73b4d0fbac54db7459ab5a23049e7c347fee3644abb
+  languageName: node
+  linkType: hard
+
+"@linaria/logger@npm:^3.0.0-beta.20":
+  version: 3.0.0-beta.20
+  resolution: "@linaria/logger@npm:3.0.0-beta.20"
+  dependencies:
+    debug: ^4.1.1
+    picocolors: ^1.0.0
+  checksum: c5c1fbe593d9110fcbf7309517530fbda419c42c4258e0854f05619f917641724718919693a0a12eb50250bace9857435f29f4de8b056e1dc5f40c01eb074a7a
+  languageName: node
+  linkType: hard
+
+"@linaria/preeval@npm:^3.0.0-beta.23":
+  version: 3.0.0-beta.23
+  resolution: "@linaria/preeval@npm:3.0.0-beta.23"
+  dependencies:
+    "@linaria/babel-preset": ^3.0.0-beta.23
+  checksum: a81b9592968502f7b1a3c8a5f6a7e435ddbddf014ae5722a730675205bee9f978a97443473e79af502d06ee0304ba788ddcc01db4cb2d2a61c25eaeeb499ce63
+  languageName: node
+  linkType: hard
+
+"@linaria/rollup@npm:3.0.0-beta.23":
+  version: 3.0.0-beta.23
+  resolution: "@linaria/rollup@npm:3.0.0-beta.23"
+  dependencies:
+    "@linaria/babel-preset": ^3.0.0-beta.23
+    "@rollup/pluginutils": ^4.1.0
+  checksum: a892a3f2a1fe8e1103f263eaa1ffbe87975aa8b232e79a58d345ce13ffd6538f5fde113d78279e081c4340a854cd93160f71a9b1ea64b0efac7346bbf705165a
+  languageName: node
+  linkType: hard
+
+"@linaria/shaker@npm:3.0.0-beta.23":
+  version: 3.0.0-beta.23
+  resolution: "@linaria/shaker@npm:3.0.0-beta.23"
+  dependencies:
+    "@babel/core": ^7.18.2
+    "@babel/generator": ">=7"
+    "@babel/plugin-transform-runtime": ">=7"
+    "@babel/plugin-transform-template-literals": ">=7"
+    "@babel/preset-env": ">=7"
+    "@linaria/babel-preset": ^3.0.0-beta.23
+    "@linaria/logger": ^3.0.0-beta.20
+    "@linaria/preeval": ^3.0.0-beta.23
+    babel-plugin-transform-react-remove-prop-types: ^0.4.24
+    ts-invariant: ^0.10.3
+  checksum: 9d50f5d8d53620335a596b2248cb1636c8cbb9bf9c5c7d3a5ab975801c712085c1b03d1babf1657bbe3a9a23e14ab6d60f1abd8c2feaf179e408db5396fb79f0
+  languageName: node
+  linkType: hard
+
+"@linaria/stylelint@npm:3.0.0-beta.23":
+  version: 3.0.0-beta.23
+  resolution: "@linaria/stylelint@npm:3.0.0-beta.23"
+  dependencies:
+    "@linaria/babel-preset": ^3.0.0-beta.23
+    strip-ansi: ^5.2.0
+  checksum: 8355c3e1634544f6057332c151b24aef6b94c3074ec59b31894e627474f83230089a82dc64dd51a437364b742ea7ca50982c50854be1e1d86597953c8a37922e
+  languageName: node
+  linkType: hard
+
+"@linaria/utils@npm:^3.0.0-beta.20":
+  version: 3.0.0-beta.20
+  resolution: "@linaria/utils@npm:3.0.0-beta.20"
+  checksum: dbf2170bf89a06fd7158b979069ca0a445a56baeebe258109a2490d4709dacc5c4b1a3628cd179ba991478809907847e0460c0c32ac92f3d427f9056e2b8c152
+  languageName: node
+  linkType: hard
+
 "@mapbox/node-pre-gyp@npm:^1.0.0":
   version: 1.0.10
   resolution: "@mapbox/node-pre-gyp@npm:1.0.10"
@@ -1793,6 +2855,16 @@ __metadata:
   version: 1.0.3
   resolution: "@remix-run/router@npm:1.0.3"
   checksum: 7e535f3c24bf6b0a48aff3de70ee74e5402fe93105aa9bd01f275d5d8f5a9a8a7cadec08d18cf5544d4f24bc9d7a091abc1c9d4ea8efb2893e9077f104a51459
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^4.1.0":
+  version: 4.2.1
+  resolution: "@rollup/pluginutils@npm:4.2.1"
+  dependencies:
+    estree-walker: ^2.0.1
+    picomatch: ^2.2.2
+  checksum: 6bc41f22b1a0f1efec3043899e4d3b6b1497b3dea4d94292d8f83b4cf07a1073ecbaedd562a22d11913ff7659f459677b01b09e9598a98936e746780ecc93a12
   languageName: node
   linkType: hard
 
@@ -2413,6 +3485,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "ajv-formats@npm:2.1.1"
+  dependencies:
+    ajv: ^8.0.0
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 4a287d937f1ebaad4683249a4c40c0fa3beed30d9ddc0adba04859026a622da0d317851316ea64b3680dc60f5c3c708105ddd5d5db8fe595d9d0207fd19f90b7
+  languageName: node
+  linkType: hard
+
+"ajv-keywords@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "ajv-keywords@npm:5.1.0"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+  peerDependencies:
+    ajv: ^8.8.2
+  checksum: c35193940b853119242c6757787f09ecf89a2c19bcd36d03ed1a615e710d19d450cb448bfda407b939aba54b002368c8bff30529cc50a0536a8e10bcce300421
+  languageName: node
+  linkType: hard
+
 "ajv@npm:^6.10.0, ajv@npm:^6.12.4":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
@@ -2422,6 +3519,18 @@ __metadata:
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
   checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.0, ajv@npm:^8.8.0":
+  version: 8.11.2
+  resolution: "ajv@npm:8.11.2"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: 53435bf79ee7d1eabba8085962dba4c08d08593334b304db7772887f0b7beebc1b3d957432f7437ed4b60e53b5d966a57b439869890209c50fed610459999e3e
   languageName: node
   linkType: hard
 
@@ -2443,6 +3552,13 @@ __metadata:
   dependencies:
     type-fest: ^0.21.3
   checksum: 93111c42189c0a6bed9cdb4d7f2829548e943827ee8479c74d6e0b22ee127b2a21d3f8b5ca57723b8ef78ce011fbfc2784350eb2bde3ccfccf2f575fa8489815
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:^4.1.0":
+  version: 4.1.1
+  resolution: "ansi-regex@npm:4.1.1"
+  checksum: b1a6ee44cb6ecdabaa770b2ed500542714d4395d71c7e5c25baa631f680fb2ad322eb9ba697548d498a6fd366949fc8b5bfcf48d49a32803611f648005b01888
   languageName: node
   linkType: hard
 
@@ -2679,6 +3795,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-loader@npm:9.1.0":
+  version: 9.1.0
+  resolution: "babel-loader@npm:9.1.0"
+  dependencies:
+    find-cache-dir: ^3.3.2
+    schema-utils: ^4.0.0
+  peerDependencies:
+    "@babel/core": ^7.12.0
+    webpack: ">=5"
+  checksum: 774758febd1e8ca804abcae3b8f65634330dc688837424d0946f06d1386914de43435cce691710fa144eccdf1292cf883439ac3598ce7320916acfaaa2372641
+  languageName: node
+  linkType: hard
+
 "babel-plugin-istanbul@npm:^6.1.1":
   version: 6.1.1
   resolution: "babel-plugin-istanbul@npm:6.1.1"
@@ -2704,14 +3833,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-macros@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "babel-plugin-macros@npm:3.1.0"
+"babel-plugin-module-resolver@npm:4.1.0":
+  version: 4.1.0
+  resolution: "babel-plugin-module-resolver@npm:4.1.0"
   dependencies:
-    "@babel/runtime": ^7.12.5
-    cosmiconfig: ^7.0.0
-    resolve: ^1.19.0
-  checksum: 765de4abebd3e4688ebdfbff8571ddc8cd8061f839bb6c3e550b0344a4027b04c60491f843296ce3f3379fb356cc873d57a9ee6694262547eb822c14a25be9a6
+    find-babel-config: ^1.2.0
+    glob: ^7.1.6
+    pkg-up: ^3.1.0
+    reselect: ^4.0.0
+    resolve: ^1.13.1
+  checksum: 3907fba21ca3c66a081e01fbd16bb09c84781749db16aa57805becc376bb5ee8dc373d4b209613e1453d30ea6c836d13073e9e7b6d239ff1806dd1763a9ab18f
+  languageName: node
+  linkType: hard
+
+"babel-plugin-polyfill-corejs2@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "babel-plugin-polyfill-corejs2@npm:0.3.3"
+  dependencies:
+    "@babel/compat-data": ^7.17.7
+    "@babel/helper-define-polyfill-provider": ^0.3.3
+    semver: ^6.1.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7db3044993f3dddb3cc3d407bc82e640964a3bfe22de05d90e1f8f7a5cb71460011ab136d3c03c6c1ba428359ebf635688cd6205e28d0469bba221985f5c6179
+  languageName: node
+  linkType: hard
+
+"babel-plugin-polyfill-corejs3@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "babel-plugin-polyfill-corejs3@npm:0.6.0"
+  dependencies:
+    "@babel/helper-define-polyfill-provider": ^0.3.3
+    core-js-compat: ^3.25.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 470bb8c59f7c0912bd77fe1b5a2e72f349b3f65bbdee1d60d6eb7e1f4a085c6f24b2dd5ab4ac6c2df6444a96b070ef6790eccc9edb6a2668c60d33133bfb62c6
+  languageName: node
+  linkType: hard
+
+"babel-plugin-polyfill-regenerator@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "babel-plugin-polyfill-regenerator@npm:0.4.1"
+  dependencies:
+    "@babel/helper-define-polyfill-provider": ^0.3.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ab0355efbad17d29492503230387679dfb780b63b25408990d2e4cf421012dae61d6199ddc309f4d2409ce4e9d3002d187702700dd8f4f8770ebbba651ed066c
+  languageName: node
+  linkType: hard
+
+"babel-plugin-transform-react-remove-prop-types@npm:^0.4.24":
+  version: 0.4.24
+  resolution: "babel-plugin-transform-react-remove-prop-types@npm:0.4.24"
+  checksum: 54afe56d67f0d118c9da23996f39948e502a152b3f582eb6e8f163fcb76c2c1ea4e0cdd4f9fac5c0ef050eab4fe0a950b0b74aae6237bcc0d31d8fc4cc808d1a
   languageName: node
   linkType: hard
 
@@ -2805,7 +3979,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.21.3":
+"browserslist@npm:^4.21.3, browserslist@npm:^4.21.4":
   version: 4.21.4
   resolution: "browserslist@npm:4.21.4"
   dependencies:
@@ -2877,6 +4051,31 @@ __metadata:
     function-bind: ^1.1.1
     get-intrinsic: ^1.0.2
   checksum: f8e31de9d19988a4b80f3e704788c4a2d6b6f3d17cfec4f57dc29ced450c53a49270dc66bf0fbd693329ee948dd33e6c90a329519aef17474a4d961e8d6426b0
+  languageName: node
+  linkType: hard
+
+"caller-callsite@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "caller-callsite@npm:2.0.0"
+  dependencies:
+    callsites: ^2.0.0
+  checksum: b685e9d126d9247b320cfdfeb3bc8da0c4be28d8fb98c471a96bc51aab3130099898a2fe3bf0308f0fe048d64c37d6d09f563958b9afce1a1e5e63d879c128a2
+  languageName: node
+  linkType: hard
+
+"caller-path@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "caller-path@npm:2.0.0"
+  dependencies:
+    caller-callsite: ^2.0.0
+  checksum: 3e12ccd0c71ec10a057aac69e3ec175b721ca858c640df021ef0d25999e22f7c1d864934b596b7d47038e9b56b7ec315add042abbd15caac882998b50102fb12
+  languageName: node
+  linkType: hard
+
+"callsites@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "callsites@npm:2.0.0"
+  checksum: be2f67b247df913732b7dec1ec0bbfcdbaea263e5a95968b19ec7965affae9496b970e3024317e6d4baa8e28dc6ba0cec03f46fdddc2fdcc51396600e53c2623
   languageName: node
   linkType: hard
 
@@ -3190,6 +4389,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commondir@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "commondir@npm:1.0.1"
+  checksum: 59715f2fc456a73f68826285718503340b9f0dd89bfffc42749906c5cf3d4277ef11ef1cca0350d0e79204f00f1f6d83851ececc9095dc88512a697ac0b9bdcb
+  languageName: node
+  linkType: hard
+
 "compare-func@npm:^2.0.0":
   version: 2.0.0
   resolution: "compare-func@npm:2.0.0"
@@ -3270,7 +4476,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"convert-source-map@npm:^1.5.0, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
+"convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
   version: 1.9.0
   resolution: "convert-source-map@npm:1.9.0"
   checksum: dc55a1f28ddd0e9485ef13565f8f756b342f9a46c4ae18b843fe3c30c675d058d6a4823eff86d472f187b176f0adf51ea7b69ea38be34be4a63cbbf91b0593c8
@@ -3281,6 +4487,15 @@ __metadata:
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
   checksum: 63ae9933be5a2b8d4509daca5124e20c14d023c820258e484e32dc324d34c2754e71297c94a05784064ad27615037ef677e3f0c00469fb55f409d2bb21261035
+  languageName: node
+  linkType: hard
+
+"core-js-compat@npm:^3.25.1":
+  version: 3.26.1
+  resolution: "core-js-compat@npm:3.26.1"
+  dependencies:
+    browserslist: ^4.21.4
+  checksum: f222bce0002eae405327d68286e1d566037e8ac21906a47d7ecd15858adca7b12e82140db11dc43c8cc1fc066c5306120f3c27bfb2d7dbc2d20a72a2d90d38dc
   languageName: node
   linkType: hard
 
@@ -3307,6 +4522,18 @@ __metadata:
     ts-node: ">=10"
     typescript: ">=3"
   checksum: a774961868f0406d0fd75e448c2e1a0ddb95de27d477fa325a37369a2cbd892cf4d639a109082cd886840dea7707ea9bed5c38a468b52de18400c4f1d495d35a
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:^5.1.0":
+  version: 5.2.1
+  resolution: "cosmiconfig@npm:5.2.1"
+  dependencies:
+    import-fresh: ^2.0.0
+    is-directory: ^0.3.1
+    js-yaml: ^3.13.1
+    parse-json: ^4.0.0
+  checksum: 8b6f1d3c8a5ffdf663a952f17af0761adf210b7a5933d0fe8988f3ca3a1f0e1e5cbbb74d5b419c15933dd2fdcaec31dbc5cc85cb8259a822342b93b529eff89c
   languageName: node
   linkType: hard
 
@@ -4548,6 +5775,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "estree-walker@npm:2.0.2"
+  checksum: 6151e6f9828abe2259e57f5fd3761335bb0d2ebd76dc1a01048ccee22fabcfef3c0859300f6d83ff0d1927849368775ec5a6d265dde2f6de5a1be1721cd94efc
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -4706,10 +5940,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-root@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "find-root@npm:1.1.0"
-  checksum: b2a59fe4b6c932eef36c45a048ae8f93c85640212ebe8363164814990ee20f154197505965f3f4f102efc33bfb1cbc26fd17c4a2fc739ebc51b886b137cbefaf
+"find-babel-config@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "find-babel-config@npm:1.2.0"
+  dependencies:
+    json5: ^0.5.1
+    path-exists: ^3.0.0
+  checksum: 0a1785d3da9f38637885d9d65f183aaa072f51a834f733035e9694e4d0f6983ae8c8e75cd4e08b92af6f595b3b490ee813a1c5a9b14740685aa836fa1e878583
+  languageName: node
+  linkType: hard
+
+"find-cache-dir@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "find-cache-dir@npm:3.3.2"
+  dependencies:
+    commondir: ^1.0.1
+    make-dir: ^3.0.2
+    pkg-dir: ^4.1.0
+  checksum: 1e61c2e64f5c0b1c535bd85939ae73b0e5773142713273818cc0b393ee3555fb0fd44e1a5b161b8b6c3e03e98c2fcc9c227d784850a13a90a8ab576869576817
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "find-up@npm:3.0.0"
+  dependencies:
+    locate-path: ^3.0.0
+  checksum: 38eba3fe7a66e4bc7f0f5a1366dc25508b7cfc349f852640e3678d26ad9a6d7e2c43eff0a472287de4a9753ef58f066a0ea892a256fa3636ad51b3fe1e17fae9
   languageName: node
   linkType: hard
 
@@ -4975,7 +6232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.3, glob@npm:^7.1.4":
+"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -5286,6 +6543,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"import-fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "import-fresh@npm:2.0.0"
+  dependencies:
+    caller-path: ^2.0.0
+    resolve-from: ^3.0.0
+  checksum: 610255f9753cc6775df00be08e9f43691aa39f7703e3636c45afe22346b8b545e600ccfe100c554607546fc8e861fa149a0d1da078c8adedeea30fff326eef79
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -5435,6 +6702,13 @@ __metadata:
   dependencies:
     has-tostringtag: ^1.0.0
   checksum: baa9077cdf15eb7b58c79398604ca57379b2fc4cf9aa7a9b9e295278648f628c9b201400c01c5e0f7afae56507d741185730307cbe7cad3b9f90a77e5ee342fc
+  languageName: node
+  linkType: hard
+
+"is-directory@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "is-directory@npm:0.3.1"
+  checksum: dce9a9d3981e38f2ded2a80848734824c50ee8680cd09aa477bef617949715cfc987197a2ca0176c58a9fb192a1a0d69b535c397140d241996a609d5906ae524
   languageName: node
   linkType: hard
 
@@ -6278,6 +7552,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsesc@npm:~0.5.0":
+  version: 0.5.0
+  resolution: "jsesc@npm:0.5.0"
+  bin:
+    jsesc: bin/jsesc
+  checksum: b8b44cbfc92f198ad972fba706ee6a1dfa7485321ee8c0b25f5cedd538dcb20cde3197de16a7265430fce8277a12db066219369e3d51055038946039f6e20e17
+  languageName: node
+  linkType: hard
+
 "json-parse-better-errors@npm:^1.0.1":
   version: 1.0.2
   resolution: "json-parse-better-errors@npm:1.0.2"
@@ -6310,6 +7593,15 @@ __metadata:
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
   checksum: cff44156ddce9c67c44386ad5cddf91925fe06b1d217f2da9c4910d01f358c6e3989c4d5a02683c7a5667f9727ff05831f7aa8ae66c8ff691c556f0884d49215
+  languageName: node
+  linkType: hard
+
+"json5@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "json5@npm:0.5.1"
+  bin:
+    json5: lib/cli.js
+  checksum: 9b85bf06955b23eaa4b7328aa8892e3887e81ca731dd27af04a5f5f1458fbc5e1de57a24442e3272f8a888dd1abe1cb68eb693324035f6b3aeba4fcab7667d62
   languageName: node
   linkType: hard
 
@@ -6411,8 +7703,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "learn-react@workspace:."
   dependencies:
+    "@babel/preset-typescript": 7.18.6
     "@commitlint/cli": 17.2.0
-    "@emotion/css": 11.10.5
+    "@linaria/core": 3.0.0-beta.22
+    "@linaria/rollup": 3.0.0-beta.23
+    "@linaria/shaker": 3.0.0-beta.23
+    "@linaria/stylelint": 3.0.0-beta.23
     "@stylelint/postcss-css-in-js": 0.38.0
     "@types/jest": 29.2.2
     "@types/node": 18.11.9
@@ -6422,6 +7718,8 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.42.1
     "@typescript-eslint/parser": 5.42.1
     "@vitejs/plugin-react": 2.2.0
+    babel-loader: 9.1.0
+    babel-plugin-module-resolver: 4.1.0
     cheerio: 1.0.0-rc.12
     chokidar: 3.5.3
     constate: 3.3.2
@@ -6568,6 +7866,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"locate-path@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "locate-path@npm:3.0.0"
+  dependencies:
+    p-locate: ^3.0.0
+    path-exists: ^3.0.0
+  checksum: 53db3996672f21f8b0bf2a2c645ae2c13ffdae1eeecfcd399a583bce8516c0b88dcb4222ca6efbbbeb6949df7e46860895be2c02e8d3219abd373ace3bfb4e11
+  languageName: node
+  linkType: hard
+
 "locate-path@npm:^5.0.0":
   version: 5.0.0
   resolution: "locate-path@npm:5.0.0"
@@ -6583,6 +7891,13 @@ __metadata:
   dependencies:
     p-locate: ^5.0.0
   checksum: 72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
+"lodash.debounce@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "lodash.debounce@npm:4.0.8"
+  checksum: a3f527d22c548f43ae31c861ada88b2637eb48ac6aa3eb56e82d44917971b8aa96fbb37aa60efea674dc4ee8c42074f90f7b1f772e9db375435f6c83a19b3bc6
   languageName: node
   linkType: hard
 
@@ -6669,7 +7984,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-dir@npm:^3.0.0, make-dir@npm:^3.1.0":
+"make-dir@npm:^3.0.0, make-dir@npm:^3.0.2, make-dir@npm:^3.1.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
   dependencies:
@@ -7401,7 +8716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^2.2.0":
+"p-limit@npm:^2.0.0, p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
   dependencies:
@@ -7416,6 +8731,15 @@ __metadata:
   dependencies:
     yocto-queue: ^0.1.0
   checksum: 7c3690c4dbf62ef625671e20b7bdf1cbc9534e83352a2780f165b0d3ceba21907e77ad63401708145ca4e25bfc51636588d89a8c0aeb715e6c37d1c066430360
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "p-locate@npm:3.0.0"
+  dependencies:
+    p-limit: ^2.0.0
+  checksum: 83991734a9854a05fe9dbb29f707ea8a0599391f52daac32b86f08e21415e857ffa60f0e120bfe7ce0cc4faf9274a50239c7895fc0d0579d08411e513b83a4ae
   languageName: node
   linkType: hard
 
@@ -7512,6 +8836,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-exists@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "path-exists@npm:3.0.0"
+  checksum: 96e92643aa34b4b28d0de1cd2eba52a1c5313a90c6542d03f62750d82480e20bfa62bc865d5cfc6165f5fcd5aeb0851043c40a39be5989646f223300021bae0a
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
@@ -7587,7 +8918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
@@ -7626,12 +8957,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pkg-dir@npm:^4.2.0":
+"pkg-dir@npm:^4.1.0, pkg-dir@npm:^4.2.0":
   version: 4.2.0
   resolution: "pkg-dir@npm:4.2.0"
   dependencies:
     find-up: ^4.0.0
   checksum: 9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
+  languageName: node
+  linkType: hard
+
+"pkg-up@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "pkg-up@npm:3.1.0"
+  dependencies:
+    find-up: ^3.0.0
+  checksum: 5bac346b7c7c903613c057ae3ab722f320716199d753f4a7d053d38f2b5955460f3e6ab73b4762c62fd3e947f58e04f1343e92089e7bb6091c90877406fcd8c8
   languageName: node
   linkType: hard
 
@@ -7985,10 +9325,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerate-unicode-properties@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "regenerate-unicode-properties@npm:10.1.0"
+  dependencies:
+    regenerate: ^1.4.2
+  checksum: b1a8929588433ab8b9dc1a34cf3665b3b472f79f2af6ceae00d905fc496b332b9af09c6718fb28c730918f19a00dc1d7310adbaa9b72a2ec7ad2f435da8ace17
+  languageName: node
+  linkType: hard
+
+"regenerate@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "regenerate@npm:1.4.2"
+  checksum: 3317a09b2f802da8db09aa276e469b57a6c0dd818347e05b8862959c6193408242f150db5de83c12c3fa99091ad95fb42a6db2c3329bfaa12a0ea4cbbeb30cb0
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.10":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
+  languageName: node
+  linkType: hard
+
 "regenerator-runtime@npm:^0.13.4":
   version: 0.13.10
   resolution: "regenerator-runtime@npm:0.13.10"
   checksum: 09893f5a9e82932642d9a999716b6c626dc53ef2a01307c952ebbf8e011802360163a37c304c18a6c358548be5a72b448e37209954a18696f21e438c81cbb4b9
+  languageName: node
+  linkType: hard
+
+"regenerator-transform@npm:^0.15.0":
+  version: 0.15.1
+  resolution: "regenerator-transform@npm:0.15.1"
+  dependencies:
+    "@babel/runtime": ^7.8.4
+  checksum: 2d15bdeadbbfb1d12c93f5775493d85874dbe1d405bec323da5c61ec6e701bc9eea36167483e1a5e752de9b2df59ab9a2dfff6bf3784f2b28af2279a673d29a4
   languageName: node
   linkType: hard
 
@@ -8007,6 +9379,38 @@ __metadata:
   version: 3.2.0
   resolution: "regexpp@npm:3.2.0"
   checksum: a78dc5c7158ad9ddcfe01aa9144f46e192ddbfa7b263895a70a5c6c73edd9ce85faf7c0430e59ac38839e1734e275b9c3de5c57ee3ab6edc0e0b1bdebefccef8
+  languageName: node
+  linkType: hard
+
+"regexpu-core@npm:^5.1.0":
+  version: 5.2.2
+  resolution: "regexpu-core@npm:5.2.2"
+  dependencies:
+    regenerate: ^1.4.2
+    regenerate-unicode-properties: ^10.1.0
+    regjsgen: ^0.7.1
+    regjsparser: ^0.9.1
+    unicode-match-property-ecmascript: ^2.0.0
+    unicode-match-property-value-ecmascript: ^2.1.0
+  checksum: 87c56815e20d213848d38f6b047ba52f0d632f36e791b777f59327e8d350c0743b27cc25feab64c0eadc9fe9959dde6b1261af71108a9371b72c8c26beda05ef
+  languageName: node
+  linkType: hard
+
+"regjsgen@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "regjsgen@npm:0.7.1"
+  checksum: 7cac399921c58db8e16454869283ff66871531180218064fa938ac05c11c2976792a00706c3c78bbc625e1d793ca373065ea90564e06189a751a7b4ae33acadc
+  languageName: node
+  linkType: hard
+
+"regjsparser@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "regjsparser@npm:0.9.1"
+  dependencies:
+    jsesc: ~0.5.0
+  bin:
+    regjsparser: bin/parser
+  checksum: 5e1b76afe8f1d03c3beaf9e0d935dd467589c3625f6d65fb8ffa14f224d783a0fed4bf49c2c1b8211043ef92b6117313419edf055a098ed8342e340586741afc
   languageName: node
   linkType: hard
 
@@ -8038,6 +9442,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reselect@npm:^4.0.0":
+  version: 4.1.7
+  resolution: "reselect@npm:4.1.7"
+  checksum: 738d8e2b8f0dca154ad29de6a209c9fbca2d70ae6788fd85df87f2c74b95a65bbf2d16d43a9e2faff39de34d17a29d706ba08a6b2ee5660c09589edbd19af7e1
+  languageName: node
+  linkType: hard
+
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-cwd@npm:3.0.0"
@@ -8051,6 +9462,13 @@ __metadata:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 4ceeb9113e1b1372d0cd969f3468fa042daa1dd9527b1b6bb88acb6ab55d8b9cd65dbf18819f9f9ddf0db804990901dcdaade80a215e7b2c23daae38e64f5bdf
+  languageName: node
+  linkType: hard
+
+"resolve-from@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "resolve-from@npm:3.0.0"
+  checksum: fff9819254d2d62b57f74e5c2ca9c0bdd425ca47287c4d801bc15f947533148d858229ded7793b0f59e61e49e782fffd6722048add12996e1bd4333c29669062
   languageName: node
   linkType: hard
 
@@ -8077,7 +9495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.0, resolve@npm:^1.22.1":
+"resolve@npm:^1.10.0, resolve@npm:^1.13.1, resolve@npm:^1.14.2, resolve@npm:^1.20.0, resolve@npm:^1.22.0, resolve@npm:^1.22.1":
   version: 1.22.1
   resolution: "resolve@npm:1.22.1"
   dependencies:
@@ -8103,7 +9521,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
   resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
@@ -8246,6 +9664,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"schema-utils@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "schema-utils@npm:4.0.0"
+  dependencies:
+    "@types/json-schema": ^7.0.9
+    ajv: ^8.8.0
+    ajv-formats: ^2.1.1
+    ajv-keywords: ^5.0.0
+  checksum: c843e92fdd1a5c145dbb6ffdae33e501867f9703afac67bdf35a685e49f85b1dcc10ea250033175a64bd9d31f0555bc6785b8359da0c90bcea30cf6dfbb55a8f
+  languageName: node
+  linkType: hard
+
 "semver@npm:2 || 3 || 4 || 5, semver@npm:^5.5.0":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
@@ -8277,7 +9707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.0.0, semver@npm:^6.3.0":
+"semver@npm:^6.0.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.3.0":
   version: 6.3.0
   resolution: "semver@npm:6.3.0"
   bin:
@@ -8470,17 +9900,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.5.7":
-  version: 0.5.7
-  resolution: "source-map@npm:0.5.7"
-  checksum: 5dc2043b93d2f194142c7f38f74a24670cd7a0063acdaf4bf01d2964b402257ae843c2a8fa822ad5b71013b5fcafa55af7421383da919752f22ff488bc553f4d
-  languageName: node
-  linkType: hard
-
 "source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.7.3":
+  version: 0.7.4
+  resolution: "source-map@npm:0.7.4"
+  checksum: 01cc5a74b1f0e1d626a58d36ad6898ea820567e87f18dfc9d24a9843a351aaa2ec09b87422589906d6ff1deed29693e176194dc88bcae7c9a852dc74b311dbf5
   languageName: node
   linkType: hard
 
@@ -8656,6 +10086,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-ansi@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "strip-ansi@npm:5.2.0"
+  dependencies:
+    ansi-regex: ^4.1.0
+  checksum: bdb5f76ade97062bd88e7723aa019adbfacdcba42223b19ccb528ffb9fb0b89a5be442c663c4a3fb25268eaa3f6ea19c7c3fbae830bd1562d55adccae1fcec46
+  languageName: node
+  linkType: hard
+
 "strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
@@ -8817,10 +10256,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylis@npm:4.1.3":
-  version: 4.1.3
-  resolution: "stylis@npm:4.1.3"
-  checksum: d04dbffcb9bf2c5ca8d8dc09534203c75df3bf711d33973ea22038a99cc475412a350b661ebd99cbc01daa50d7eedcf0d130d121800eb7318759a197023442a6
+"stylis@npm:^3.5.4":
+  version: 3.5.4
+  resolution: "stylis@npm:3.5.4"
+  checksum: 3673a748ad236219bd77ca9c0a8730b8726812e612cbc844aa6f029f13666a10cf2825a5f8d41f05e8af02b5987d31b7d3ebe995e4b42e0255366fec23489b77
   languageName: node
   linkType: hard
 
@@ -9030,6 +10469,15 @@ __metadata:
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: b530f3fadf78e570cf3c761fb74fef655beff6b0f84b29209bac6c9622db75ad1417f4a7b5d54c96605dcd72734ad44526fef9f396807b90839449eb543c6206
+  languageName: node
+  linkType: hard
+
+"ts-invariant@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "ts-invariant@npm:0.10.3"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: bb07d56fe4aae69d8860e0301dfdee2d375281159054bc24bf1e49e513fb0835bf7f70a11351344d213a79199c5e695f37ebbf5a447188a377ce0cd81d91ddb5
   languageName: node
   linkType: hard
 
@@ -9282,6 +10730,37 @@ __metadata:
     has-symbols: ^1.0.3
     which-boxed-primitive: ^1.0.2
   checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
+  languageName: node
+  linkType: hard
+
+"unicode-canonical-property-names-ecmascript@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.0"
+  checksum: 39be078afd014c14dcd957a7a46a60061bc37c4508ba146517f85f60361acf4c7539552645ece25de840e17e293baa5556268d091ca6762747fdd0c705001a45
+  languageName: node
+  linkType: hard
+
+"unicode-match-property-ecmascript@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-match-property-ecmascript@npm:2.0.0"
+  dependencies:
+    unicode-canonical-property-names-ecmascript: ^2.0.0
+    unicode-property-aliases-ecmascript: ^2.0.0
+  checksum: 1f34a7434a23df4885b5890ac36c5b2161a809887000be560f56ad4b11126d433c0c1c39baf1016bdabed4ec54829a6190ee37aa24919aa116dc1a5a8a62965a
+  languageName: node
+  linkType: hard
+
+"unicode-match-property-value-ecmascript@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "unicode-match-property-value-ecmascript@npm:2.1.0"
+  checksum: 8d6f5f586b9ce1ed0e84a37df6b42fdba1317a05b5df0c249962bd5da89528771e2d149837cad11aa26bcb84c35355cb9f58a10c3d41fa3b899181ece6c85220
+  languageName: node
+  linkType: hard
+
+"unicode-property-aliases-ecmascript@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "unicode-property-aliases-ecmascript@npm:2.1.0"
+  checksum: 243524431893649b62cc674d877bd64ef292d6071dd2fd01ab4d5ad26efbc104ffcd064f93f8a06b7e4ec54c172bf03f6417921a0d8c3a9994161fe1f88f815b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

- emotion はだいたい使い倒したため、新しい技術習得をする。

### 何を変更したのか

CSS-in-JS ライブラリを Linaria に乗り換えた。

[Linaria – zero-runtime CSS in JS library](https://linaria.dev/)

emotion と比較すると多少の制約はあるが[^1]、当該プロジェクト程度の規模であれば何とかカバーできそう。

[^1]: 動的なスタイルは `css` 関数でなく JSX の `style` プロパティで表現する必要がある。定義済みの `css` 関数もどり値を `cx` 関数で動的に付け外しするのは問題ない。

### 技術的にはどこがポイントか

- `keyframe` 専用の関数は存在せず、普通に `css` 関数内にアニメーションを定義する。
  - [linaria/BASICS.md at 922496ab3ef96bf394384ae07af0dc9c3591cc8b · callstack/linaria](https://github.com/callstack/linaria/blob/922496ab3ef96bf394384ae07af0dc9c3591cc8b/docs/BASICS.md#keyframe-animations)
- 2022.11 現在の最新 Ver. は `4.x` だが Vite の HMR が正常に動作しないため、この問題が解決するまで `3.0` を使う必要がある。
  - https://github.com/callstack/linaria/issues/1073
- highlight.js 用テーマ CSS を読み込む `<link>` 要素を html ファイルにハードコーディングするのをやめ、 catalog の `CodeBlock` コンポーネント内で動的に `<link>` 要素を生成・挿入するようにした。
  - html ファイル内に `<link>` 要素ががあると Vite build 時に Linaria が失敗してしまうため、これを回避するためのワークアラウンド。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
