### PR TITLE
story が属する階層名にクエリがマッチしていればナビゲーション一覧に残すようにする

### DIFF
--- a/packages/catalog/src/components/Navigation/index.tsx
+++ b/packages/catalog/src/components/Navigation/index.tsx
@@ -167,7 +167,7 @@ const Tree = ({ value, basePath, query, nestLevel = 1 }: TreeProps) => {
         const path = `${basePath}__${key}`;
 
         if (subValue.sourceCode && subValue.Component) {
-          return key.match(query) ? (
+          return path.match(query) ? (
             <li key={key}>
               <Link
                 to={path}
@@ -181,11 +181,13 @@ const Tree = ({ value, basePath, query, nestLevel = 1 }: TreeProps) => {
           ) : null;
         }
 
-        const filteredItemKeys = Object.keys(subValue).filter(subKey => subKey.match(query));
-
         return (
           <li key={key}>
-            <div className={styleTreeCaption} style={{ paddingLeft: offset }} aria-disabled={!filteredItemKeys.length}>
+            <div
+              className={styleTreeCaption}
+              style={{ paddingLeft: offset }}
+              aria-disabled={!Object.keys(subValue).filter(subKey => subKey.match(query)).length && !key.match(query)}
+            >
               <Icon name="folder" />
               {key}
             </div>


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

- story 名そのものに合致するクエリ文でないとフィルタリングされてしまい不便なため。
  - 例えば `splitpane` で検索しても一覧には出てこない。なぜなら `SplitPane` の story 名は `Horizontal` or `Vertical` のため、これら２つの名前に該当したクエリでなくてはならない。
  - `splitpane` と入力すればその配下にある `Horizontal` と `Vertical` が一覧に表示されるようにしたい。

### 何を変更したのか

入力したクエリが階層名であっても、その配下にある stories 全部が一覧に表示されるようにした。

### 技術的にはどこがポイントか

各 story が持つ path 情報とクエリがマッチするかどうかでフィルタリングするようにした。path 情報にはその story が属する階層情報の全てが含まれているため、これとクエリを突合すれば期待通りのフィルタリング結果が得られる。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
|<img width="272" alt="スクリーンショット 2022-11-17 12 17 35" src="https://user-images.githubusercontent.com/2629981/202346448-da88a86b-c9f6-4529-b077-f7b99ad57b38.png"> |  <img width="272" alt="スクリーンショット 2022-11-17 12 17 24" src="https://user-images.githubusercontent.com/2629981/202346478-a499874b-b121-4185-b6ec-6babcd9c3960.png">|
