### PR TITLE
ハードリロード時に catalog ナビゲーション中のアクティブなリンクがビューポート内に収まるようにする

### DIFF
--- a/packages/catalog/src/components/Navigation/index.tsx
+++ b/packages/catalog/src/components/Navigation/index.tsx
@@ -3,8 +3,8 @@ import { TextField } from '@learn-react/core/components/inputs/TextField';
 import { BorderRadius, Duration, FontFamily, FontSize, IconSize } from '@learn-react/core/constants/Style';
 import { cssVar, gutter, square } from '@learn-react/core/helpers/Style';
 import { css } from '@linaria/core';
-import type { FC } from 'react';
-import { useMemo, useState } from 'react';
+import type { FC, RefObject } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { stories } from '../../constants/Stories';
 import Logo from './logo192.png';
@@ -17,6 +17,10 @@ export const Navigation = () => {
 
     return new RegExp(pattern, 'i');
   }, [keyword]);
+
+  const bodyRef = useRef<HTMLElement>(null);
+
+  useAdjustScroll(bodyRef);
 
   return (
     <div role="complementary" className={styleBase}>
@@ -40,7 +44,7 @@ export const Navigation = () => {
         />
       </div>
 
-      <nav className={styleBody}>
+      <nav ref={bodyRef} className={styleBody}>
         {Object.entries(stories).map(([subPackageKey, subPackage]) => (
           <ul key={subPackageKey} className={styleNavigation} role="tree">
             <li>
@@ -53,6 +57,36 @@ export const Navigation = () => {
     </div>
   );
 };
+
+/**
+ * URL 遷移時にコンテナ要素のスクロールを調整し、アクティブとなっているナビゲーションリンクをビューポート内に収めます。
+ *
+ * 一覧の下の方にあるリンクはハードリロード時にビューポート外に追いやられてしまうことによるユーザビリティ低下の防止が期待できます。
+ *
+ * @param containerRef スクロール操作するコンテナ要素
+ */
+function useAdjustScroll(containerRef: RefObject<HTMLElement>) {
+  const location = useLocation();
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const target = container.querySelector(`[href="${location.pathname}"]`);
+    if (!target) return;
+
+    const containerOffsetTop = container.getBoundingClientRect().top;
+    const containerHeight = container.offsetHeight;
+    const targetOffsetTop = target.getBoundingClientRect().top;
+    const targetHeight = (target as HTMLElement).offsetHeight;
+
+    if (targetOffsetTop + targetHeight >= containerOffsetTop + containerHeight) {
+      container.scrollTo({
+        top: targetOffsetTop - containerHeight + containerHeight / 2,
+      });
+    }
+  }, [containerRef, location.pathname]);
+}
 
 const styleBase = css`
   display: grid;

--- a/packages/catalog/src/components/Navigation/index.tsx
+++ b/packages/catalog/src/components/Navigation/index.tsx
@@ -66,13 +66,11 @@ export const Navigation = () => {
  * @param containerRef スクロール操作するコンテナ要素
  */
 function useAdjustScroll(containerRef: RefObject<HTMLElement>) {
-  const location = useLocation();
-
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
-    const target = container.querySelector(`[href="${location.pathname}"]`);
+    const target = container.querySelector(`[aria-selected="true"]`);
     if (!target) return;
 
     const containerOffsetTop = container.getBoundingClientRect().top;
@@ -85,7 +83,7 @@ function useAdjustScroll(containerRef: RefObject<HTMLElement>) {
         top: targetOffsetTop - containerHeight + containerHeight / 2,
       });
     }
-  }, [containerRef, location.pathname]);
+  }, [containerRef]);
 }
 
 const styleBase = css`


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

リンク一覧の下の方にあるナビゲーションリンクがアクティブである状態でにハードリロードすると、ナビゲーションのスクロールがリセットされて選択中のリンクがビューポート外に見切れてしまう。
よって現在どのストーリーが表示されているのかが分かりにくい。

### 何を変更したのか

ハードリロード時にナビゲーションのスクロールを調整し、アクティブなリンクが確実にビューポート内に収まるようにした。

### 技術的にはどこがポイントか

アクティブなリンク要素（ `aria-selected="true"` ）の座標情報を取得し、コンテナ要素である `<nav>` のビューポート外ならコンテナ要素のスクロールを操作してビューポート内に収まるようにした。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
