### PR TITLE
useScrollTo のスクロール処理完了時に実行するコールバック関数を渡せるようにする

### DIFF
--- a/packages/core/src/hooks/useScrollTo/index.story.tsx
+++ b/packages/core/src/hooks/useScrollTo/index.story.tsx
@@ -14,13 +14,21 @@ export const Story = () => {
 
   const ref = useRef<HTMLDivElement>(null);
 
-  const scrollTo = useScrollTo(ref, { offset, scrollBehavior });
+  const scrollTo = useScrollTo(ref, {
+    offset,
+    scrollBehavior,
+  });
 
   const handleSelectNav = (e: MouseEvent<HTMLAnchorElement>, name: string) => {
     e.preventDefault();
 
     setTarget(name);
-    scrollTo(e => e.querySelector(`[data-spy="${name}"]`));
+    scrollTo(
+      e => e.querySelector(`[data-spy="${name}"]`),
+      () => {
+        console.info(`scroll end: ${name}`);
+      },
+    );
   };
 
   const onChangeOffset = (e: ChangeEvent<HTMLInputElement>) => {

--- a/packages/core/src/hooks/useScrollTo/index.story.tsx
+++ b/packages/core/src/hooks/useScrollTo/index.story.tsx
@@ -16,7 +16,7 @@ export const Story = () => {
 
   const scrollTo = useScrollTo(ref, {
     offset,
-    scrollBehavior,
+    behavior: scrollBehavior,
   });
 
   const handleSelectNav = (e: MouseEvent<HTMLAnchorElement>, name: string) => {

--- a/packages/core/src/hooks/useSpy/Basic.story.tsx
+++ b/packages/core/src/hooks/useSpy/Basic.story.tsx
@@ -37,7 +37,7 @@ export const Story = () => {
       <div
         ref={
           // spy('[data-spy]', onSpyChange) のようにセレクターに文字列だけ渡すこともできるが、
-          // このような高度な選び方もできる。
+          // このような高度な選び方も可能。
           spy(
             e =>
               [...e.querySelectorAll('[data-spy]')].filter(e => !(e as HTMLElement).dataset.spy?.startsWith('rotten')),


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

`useSpy` 同様、 `useScrollTo` にも処理完了後にコールバック関数を実行させられるようにした方が便利なため。

### 何を変更したのか

`useScrollTo` の戻り値である `scrollTo` の引数にコールバック関数を渡せるようにした。
このコールバック関数はスクロール処理完了後に呼び出される。

### 技術的にはどこがポイントか

`useScrollTo` 自体の引数にコールバック関数を渡す設計の方が内部実装はシンプルになるのだが、利用側の宣言順序がちぐはぐになってしまうリスクがあるため、現状の設計に落ち着いた。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
