### PR TITLE
catalog を s3 にデプロイするスクリプトを実装する

### DIFF
--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -35,3 +35,13 @@ yarn prepare-msw
 ```bash
 [ENV_TARGET=<target>] [ENV_VARIANT=<variant>] yarn build [--mode=<mode>]
 ```
+
+## Deployment
+
+### Requirement
+
+- [AWS CLI](https://aws.amazon.com/jp/cli/)
+
+```bash
+yarn deploy
+```

--- a/packages/catalog/bin/sync-s3.sh
+++ b/packages/catalog/bin/sync-s3.sh
@@ -1,0 +1,5 @@
+#!/bin/sh +xe
+
+aws --profile note \
+  --region ap-northeast-1 s3 sync ./dist s3://learn-react.wakamsha.net \
+  --cache-control "private, no-store, no-cache"

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -13,6 +13,7 @@
     "type-check": "run -T tsc --noEmit",
     "start": "run-p \"generate --watch\" \"type-check --watch\" \"develop {@}\" --",
     "build": "yarn generate && yarn type-check && vite build",
-    "preview": "run -T vite preview"
+    "preview": "run -T vite preview",
+    "deploy": "bash ./bin/sync-s3.sh"
   }
 }


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

頻度は少ないものの、AWS マネジメントコンソール上で S3 にアップロードするコストが惜しいため。

### 何を変更したのか

当該プロジェクトから catalog を S3 に直接アップロードできる npm script を実装した。

### 技術的にはどこがポイントか

aws-cli を npm script から直接呼び出している。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

本来ならアップロードする度に CloudFront のキャッシュを削除する必要があるはずなのだが、なぜか即座に更新が反映されていたため、今回はキャッシュ削除スクリプトの実装を見送った。

今後必要になるようであれば、追加実装する。

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
