### PR TITLE
SplitPane の各種 `size` プロパティをパーセンテージでも指定できるようにする

### DIFF
--- a/packages/catalog/index.html
+++ b/packages/catalog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <meta name="description" content="goodbye world" />
+    <meta name="description" content="This site lists React components and custom hooks developed by wakamsha." />
     <title>Catalog | Learn React</title>
   </head>
 

--- a/packages/core/src/components/utils/SplitPane/Horizontal.story.tsx
+++ b/packages/core/src/components/utils/SplitPane/Horizontal.story.tsx
@@ -3,9 +3,9 @@ import { SplitPane } from '.';
 export const Story = () => (
   <div style={{ height: 480, overflow: 'hidden' }}>
     <SplitPane
-      minSize={100}
-      maxSize={600}
-      defaultSize={240}
+      minSize="100px"
+      maxSize="600px"
+      defaultSize="40%"
       primary="second"
       onStarted={() => console.info('started')}
       onFinished={console.info}

--- a/packages/core/src/components/utils/SplitPane/Pane.tsx
+++ b/packages/core/src/components/utils/SplitPane/Pane.tsx
@@ -7,7 +7,7 @@ type ParentProps = ComponentProps<typeof SplitPane>;
 
 type Props = Required<Pick<ParentProps, 'orientation'>> & {
   children: ReactNode;
-  size?: number;
+  size?: `${number}px` | `${number}%`;
 };
 
 export const Pane = forwardRef(({ orientation, children, size }: Props, ref: ForwardedRef<HTMLDivElement>) => {

--- a/packages/core/src/components/utils/SplitPane/Vertical.story.tsx
+++ b/packages/core/src/components/utils/SplitPane/Vertical.story.tsx
@@ -4,9 +4,9 @@ export const Story = () => (
   <div style={{ height: 480, overflow: 'hidden' }}>
     <SplitPane
       orientation="vertical"
-      minSize={100}
-      maxSize={360}
-      defaultSize={240}
+      minSize="100px"
+      maxSize="360px"
+      defaultSize="40%"
       onStarted={() => console.info('started')}
       onFinished={console.info}
     >


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

`SplitPane` を catalog の `StoryPage` に導入する際にパーセンテージ指定できる必要があるため。

### 何を変更したのか

`SplitPane` の `minSize` , `maxSize` , `defaultSize` プロパティを px だけでなくパーセンテージでも指定できるようにした。

### 技術的にはどこがポイントか

ドラッグ操作によって変化する pane のサイズは px 値として計算・表現する必要があるため、パーセンテージで渡した値は内部で px 値の number 型に変換してから処理に使うようにした。 px 値で渡した値はそのまま number 型に変換するだけで処理に使っている。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

- #789 

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
