### PR TITLE
useListBox  を Button, IconButton と組み合わせて使えるようにする

### DIFF
--- a/packages/core/src/components/inputs/Button/index.tsx
+++ b/packages/core/src/components/inputs/Button/index.tsx
@@ -218,7 +218,6 @@ const styleBase = css`
   > svg {
     margin-top: -1px;
     margin-bottom: -1px;
-    pointer-events: none;
     ${square(16)}
 
     &:first-child:not(:last-child) {
@@ -228,10 +227,6 @@ const styleBase = css`
     &:last-child:not(:first-child) {
       margin-right: ${gutter(-2)};
     }
-  }
-
-  > span {
-    pointer-events: none;
   }
 `;
 

--- a/packages/core/src/components/inputs/IconButton/index.tsx
+++ b/packages/core/src/components/inputs/IconButton/index.tsx
@@ -183,10 +183,6 @@ const styleBase = css`
   &:active {
     transition: none;
   }
-
-  > svg {
-    pointer-events: none;
-  }
 `;
 
 const styleSolid: Frozen<Theme, string> = {

--- a/packages/core/src/components/inputs/IconButton/index.tsx
+++ b/packages/core/src/components/inputs/IconButton/index.tsx
@@ -1,7 +1,7 @@
 import type { IconName } from '@learn-react/icon';
 import { css, cx } from '@linaria/core';
-import type { MouseEvent } from 'react';
-import { useMemo } from 'react';
+import type { AriaAttributes, ForwardedRef, KeyboardEvent, MouseEvent } from 'react';
+import { forwardRef, useMemo } from 'react';
 import { BorderRadius, Duration } from '../../../constants/Style';
 import { cssVar, square } from '../../../helpers/Style';
 import { Icon } from '../../dataDisplay/Icon';
@@ -23,8 +23,18 @@ type Props = {
   theme?: Theme;
   size?: Size;
   /** アクセシビリティのために指定するラベルです。 */
-  ariaLabel?: string;
+  ariaLabel?: AriaAttributes['aria-label'];
   disabled?: boolean;
+  tabIndex?: number;
+  onKeyDown?: (e: KeyboardEvent<HTMLButtonElement>) => void;
+  /**
+   * メニューやダイアログなど、要素によって起動されるインタラクティブなポップアップ要素の有無と種類を示します。
+   */
+  ariaHaspopup?: AriaAttributes['aria-haspopup'];
+  /**
+   * 要素、またはそれが制御する別のグループ化要素が現在展開されているか、または折りたたまれているかを示します。
+   */
+  ariaExpanded?: AriaAttributes['aria-expanded'];
 };
 
 /**
@@ -35,35 +45,48 @@ type Props = {
  *
  * @param props
  */
-export const IconButton = ({
-  name,
-  id,
-  variant = 'solid',
-  theme = 'primary',
-  size = 'neutral',
-  ariaLabel,
-  disabled,
-  onClick,
-}: Props) => {
-  const styleButton = useMemo(
-    () => cx(styleBase, getVariantStyle(variant, theme), styleSize[size]),
-    [theme, variant, size],
-  );
+export const IconButton = forwardRef(
+  (
+    {
+      name,
+      id,
+      variant = 'solid',
+      theme = 'primary',
+      size = 'neutral',
+      ariaLabel,
+      disabled,
+      tabIndex = -1,
+      onClick,
+      onKeyDown,
+      ariaHaspopup,
+      ariaExpanded,
+    }: Props,
+    ref: ForwardedRef<HTMLButtonElement>,
+  ) => {
+    const styleButton = useMemo(
+      () => cx(styleBase, getVariantStyle(variant, theme), styleSize[size]),
+      [theme, variant, size],
+    );
 
-  return (
-    <button
-      type="button"
-      aria-label={ariaLabel}
-      id={id}
-      className={styleButton}
-      tabIndex={-1}
-      disabled={disabled}
-      onClick={onClick}
-    >
-      <Icon name={name} />
-    </button>
-  );
-};
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-label={ariaLabel}
+        id={id}
+        className={styleButton}
+        tabIndex={tabIndex}
+        disabled={disabled}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+        aria-haspopup={ariaHaspopup}
+        aria-expanded={ariaExpanded}
+      >
+        <Icon name={name} />
+      </button>
+    );
+  },
+);
 
 function getVariantStyle(variant: Variant, theme: Theme) {
   switch (variant) {
@@ -159,6 +182,10 @@ const styleBase = css`
 
   &:active {
     transition: none;
+  }
+
+  > svg {
+    pointer-events: none;
   }
 `;
 

--- a/packages/core/src/components/navigation/Menu/index.tsx
+++ b/packages/core/src/components/navigation/Menu/index.tsx
@@ -89,8 +89,8 @@ export function useDropdownMenu(itemCount: number, options?: DropdownMenuOptions
     const handleEveryClick = (e: globalThis.MouseEvent) => {
       if (
         !(e.target instanceof Element) ||
-        e.target === buttonRef.current ||
-        e.target.closest('[role="menu"]') instanceof Element
+        e.target.closest('[role="menu"]') instanceof Element ||
+        e.target.closest('[aria-haspopup="true"][aria-expanded="true"]') === buttonRef.current
       )
         return;
       setOpened(false);

--- a/packages/core/src/hooks/useListBox/Basic.story.tsx
+++ b/packages/core/src/hooks/useListBox/Basic.story.tsx
@@ -1,0 +1,92 @@
+import { css } from '@linaria/core';
+import { useState } from 'react';
+import { useListBox } from '.';
+import { FontSize } from '../../constants/Style';
+import { cssVar, gutter } from '../../helpers/Style';
+
+export const Story = () => {
+  const menuItems = ['foo', 'bar', 'baz', 'hello', 'world', 'aaa', 'bbb'];
+
+  const { itemProps, active, setActive, triggerProps } = useListBox(menuItems.length);
+
+  const [value, setValue] = useState('');
+
+  const handleSelect = (value: string) => {
+    setValue(value);
+    setActive(false);
+  };
+
+  return (
+    <>
+      <pre>
+        <code>{JSON.stringify(value, null, 2)}</code>
+      </pre>
+      <hr />
+      <button
+        ref={triggerProps.ref}
+        onKeyDown={triggerProps.onKeyDown}
+        onClick={triggerProps.onClick}
+        tabIndex={triggerProps.tabIndex}
+        role={triggerProps.role}
+        aria-haspopup={triggerProps['aria-haspopup']}
+        aria-expanded={triggerProps['aria-expanded']}
+      >
+        Open
+      </button>
+      <ul className={styleMenu} role="menu" aria-hidden={!active}>
+        {menuItems.map((item, index) => (
+          <li key={item}>
+            <button
+              className={styleMenuItem}
+              onClick={() => handleSelect(item)}
+              onKeyDown={itemProps[index].onKeyDown}
+              tabIndex={itemProps[index].tabIndex}
+              role={itemProps[index].role}
+              ref={itemProps[index].ref}
+            >
+              {item}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+const styleMenu = css`
+  display: none;
+  width: 240px;
+  max-height: 120px;
+  padding: ${gutter(2)} 0;
+  overflow: auto;
+  font-size: ${FontSize.Regular};
+  background-color: ${cssVar('TexturePaper')};
+  box-shadow: ${cssVar('ShadowDialog')};
+
+  &[aria-hidden='false'] {
+    display: block;
+  }
+
+  > :not(:first-child) {
+    border-top: 1px solid ${cssVar('LineLight')};
+  }
+`;
+
+const styleMenuItem = css`
+  display: block;
+  width: 100%;
+  padding: ${gutter(1)} ${gutter(2)};
+  text-align: left;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  appearance: none;
+
+  &:hover {
+    background-color: ${cssVar('ThemePrimaryLight')};
+  }
+
+  &:focus {
+    background-color: ${cssVar('ThemePrimaryNeutral')};
+  }
+`;

--- a/packages/core/src/hooks/useListBox/WithButton.story.tsx
+++ b/packages/core/src/hooks/useListBox/WithButton.story.tsx
@@ -1,0 +1,91 @@
+import { css } from '@linaria/core';
+import { useState } from 'react';
+import { useListBox } from '.';
+import { IconButton } from '../../components/inputs/IconButton';
+import { FontSize } from '../../constants/Style';
+import { cssVar, gutter } from '../../helpers/Style';
+
+export const Story = () => {
+  const menuItems = ['foo', 'bar', 'baz', 'hello', 'world', 'aaa', 'bbb'];
+
+  const { itemProps, active, setActive, triggerProps } = useListBox(menuItems.length);
+
+  const [value, setValue] = useState('');
+
+  const handleSelect = (value: string) => {
+    setValue(value);
+    setActive(false);
+  };
+
+  return (
+    <>
+      <pre>
+        <code>{JSON.stringify(value, null, 2)}</code>
+      </pre>
+      <hr />
+      <IconButton
+        name="list"
+        ref={triggerProps.ref}
+        onKeyDown={triggerProps.onKeyDown}
+        onClick={triggerProps.onClick}
+        tabIndex={triggerProps.tabIndex}
+        ariaHaspopup={triggerProps['aria-haspopup'] as any}
+        ariaExpanded={triggerProps['aria-expanded'] as any}
+      />
+      <ul className={styleMenu} role="menu" aria-hidden={!active}>
+        {menuItems.map((item, index) => (
+          <li key={item}>
+            <button
+              className={styleMenuItem}
+              onClick={() => handleSelect(item)}
+              onKeyDown={itemProps[index].onKeyDown}
+              tabIndex={itemProps[index].tabIndex}
+              role={itemProps[index].role}
+              ref={itemProps[index].ref}
+            >
+              {item}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+const styleMenu = css`
+  display: none;
+  width: 240px;
+  max-height: 120px;
+  padding: ${gutter(2)} 0;
+  overflow: auto;
+  font-size: ${FontSize.Regular};
+  background-color: ${cssVar('TexturePaper')};
+  box-shadow: ${cssVar('ShadowDialog')};
+
+  &[aria-hidden='false'] {
+    display: block;
+  }
+
+  > :not(:first-child) {
+    border-top: 1px solid ${cssVar('LineLight')};
+  }
+`;
+
+const styleMenuItem = css`
+  display: block;
+  width: 100%;
+  padding: ${gutter(1)} ${gutter(2)};
+  text-align: left;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  appearance: none;
+
+  &:hover {
+    background-color: ${cssVar('ThemePrimaryLight')};
+  }
+
+  &:focus {
+    background-color: ${cssVar('ThemePrimaryNeutral')};
+  }
+`;

--- a/packages/core/src/hooks/useListBox/WithIconButton.story.tsx
+++ b/packages/core/src/hooks/useListBox/WithIconButton.story.tsx
@@ -1,6 +1,8 @@
 import { css } from '@linaria/core';
 import { useState } from 'react';
 import { useListBox } from '.';
+import { Icon } from '../../components/dataDisplay/Icon';
+import { Button } from '../../components/inputs/Button';
 import { FontSize } from '../../constants/Style';
 import { cssVar, gutter } from '../../helpers/Style';
 
@@ -18,18 +20,24 @@ export const Story = () => {
 
   return (
     <>
-      <h2>Basic</h2>
-      <button
+      <pre>
+        <code>{JSON.stringify(value, null, 2)}</code>
+      </pre>
+
+      <hr />
+
+      <Button
         ref={triggerProps.ref}
         onKeyDown={triggerProps.onKeyDown}
         onClick={triggerProps.onClick}
         tabIndex={triggerProps.tabIndex}
-        role={triggerProps.role}
-        aria-haspopup={triggerProps['aria-haspopup']}
-        aria-expanded={triggerProps['aria-expanded']}
+        ariaHaspopup={triggerProps['aria-haspopup']}
+        ariaExpanded={triggerProps['aria-expanded']}
       >
         Open
-      </button>
+        <Icon name="angle-bottom" />
+      </Button>
+
       <ul className={styleMenu} role="menu" aria-hidden={!active}>
         {menuItems.map((item, index) => (
           <li key={item}>
@@ -46,10 +54,6 @@ export const Story = () => {
           </li>
         ))}
       </ul>
-      <hr />
-      <pre>
-        <code>{JSON.stringify(value, null, 2)}</code>
-      </pre>
     </>
   );
 };

--- a/packages/core/src/hooks/useListBox/index.ts
+++ b/packages/core/src/hooks/useListBox/index.ts
@@ -11,9 +11,11 @@ import { createRef, useCallback, useEffect, useMemo, useRef, useState } from 're
 
 type TriggerProps = {
   ref: RefObject<HTMLButtonElement>;
-} & Pick<
-  DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
-  'onKeyDown' | 'onClick' | 'tabIndex' | 'role' | 'aria-haspopup' | 'aria-expanded'
+} & Required<
+  Pick<
+    DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
+    'onKeyDown' | 'onClick' | 'tabIndex' | 'role' | 'aria-haspopup' | 'aria-expanded'
+  >
 >;
 
 type Response = Readonly<{
@@ -181,6 +183,7 @@ export function useListBox(itemCount: number): Response {
         e.target.closest('[role="menu"]') instanceof Element
       )
         return;
+
       setActive(active => !active);
     };
 

--- a/packages/core/src/hooks/useListBox/index.ts
+++ b/packages/core/src/hooks/useListBox/index.ts
@@ -179,8 +179,8 @@ export function useListBox(itemCount: number): Response {
     const handleEveryClick = (e: globalThis.MouseEvent) => {
       if (
         !(e.target instanceof Element) ||
-        e.target === triggerRef.current ||
-        e.target.closest('[role="menu"]') instanceof Element
+        e.target.closest('[role="menu"]') instanceof Element ||
+        e.target.closest('[aria-haspopup="true"][aria-expanded="true"]') === triggerRef.current
       )
         return;
 


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

`useListBox` のトリガーに `Button` , `IconButton` を使えるようにするため。

### 何を変更したのか

<!-- このPRで何を変更をしたかの概要を記述 -->

- listbox が表示できない不具合を修正した。
　　- #521 での修正が不足していたため、この PR は追加対応にあたる。
- `useListBox` のトリガーにする上で必要な props を `Button` , `IconButton` に追加した。
  - `RefObject` を渡せるようにした。
  - `onKeyDown` , `aria-haspopup` , `aria-expanded` を渡せるようにした。
- `useListBox` の戻り値のうち `triggerProps` の型を Required にする。
- `useListBox` + `Button`, `useListBox` + `IconButton` な stories を追加した。

### 技術的にはどこがポイントか

<!-- レビュワーにわかるように、技術的視線での変更概要説明 -->
クリック対象が `targetRef` の子要素だと、そのイベントが伝搬して #521 で追加したガード節を通過してしまっていたのが原因。
クリックイベントオブジェクトの親要素が `targetRef` かどうかをガード節の条件式に追加するようにした。


### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

- #521 

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
