### PR TITLE
Navigation コンポーネントの width を調整する

### DIFF
--- a/packages/catalog/src/components/Layout/index.tsx
+++ b/packages/catalog/src/components/Layout/index.tsx
@@ -114,7 +114,7 @@ const styleNavigationWrapper: Frozen<LayoutMode, LinariaClassName> = {
 
 const styleToggleButtonWrapperBase = css`
   position: fixed;
-  top: ${gutter(4)};
+  top: ${gutter(2)};
   z-index: 2;
   transition: left ${Duration.Fade} ${Easing.Enter};
 `;

--- a/packages/catalog/src/components/Layout/index.tsx
+++ b/packages/catalog/src/components/Layout/index.tsx
@@ -53,8 +53,8 @@ export const Layout = ({ children }: Props) => {
 };
 
 const delayTime = 300;
-const navigationWidth = 272;
-const navigationGutter = 48;
+const navigationWidth = 256;
+const navigationGutter = 64;
 
 const styleBaseBase = css`
   width: 100%;
@@ -129,7 +129,7 @@ const styleToggleButtonWrapper: Frozen<LayoutMode, LinariaClassName> = {
   [LayoutMode.Zen]: cx(
     styleToggleButtonWrapperBase,
     css`
-      left: ${gutter(2)};
+      left: ${gutter(4)};
     `,
   ),
 };

--- a/packages/catalog/src/components/Navigation/index.tsx
+++ b/packages/catalog/src/components/Navigation/index.tsx
@@ -97,12 +97,9 @@ const styleBase = css`
 `;
 
 const styleMasthead = css`
-  flex-shrink: 0;
-  padding: ${gutter(3)} ${gutter(4)} 0;
-
-  > :not(:first-child) {
-    margin-top: ${gutter(2)};
-  }
+  display: grid;
+  gap: ${gutter(2)};
+  padding: ${gutter(2)} ${gutter(4)} 0;
 `;
 
 const styleLogo = css`
@@ -111,7 +108,7 @@ const styleLogo = css`
   margin: auto;
   background-color: ${cssVar('ThemePrimaryDarker')};
   border-radius: ${BorderRadius.Circle};
-  ${square(40)}
+  ${square(32)}
 `;
 
 const styleTitle = css`


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

- Navigation 展開時の width が少々広すぎるのを調整したい。
- Navigation 格納時の toggle button と Navigation 内コンテンツの縦位置を左揃えにしたい。

### 何を変更したのか

<!-- このPRで何を変更をしたかの概要を記述 -->

- Navigation 中の logo のサイズを小さくした。
- Navigation 展開時のサイズを `272px` から `256px` にした。
- Navigation 格納時の幅を `48px` から `56px` にした。
  - toggle button と Navigation 内コンテンツが左揃えにするため。
- navigation header 内を grid layout にした。

### 技術的にはどこがポイントか

<!-- レビュワーにわかるように、技術的視線での変更概要説明 -->

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
