### PR TITLE
Popover の表示・非表示のロジックを修正する

### DIFF
--- a/packages/core/src/components/utils/Popover/index.tsx
+++ b/packages/core/src/components/utils/Popover/index.tsx
@@ -259,10 +259,13 @@ const styleBase = css`
   right: 0;
   bottom: 0;
   left: 0;
-  visibility: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity ${Duration.Fade};
 
   &[aria-hidden='false'] {
-    visibility: visible;
+    pointer-events: auto;
+    opacity: 1;
   }
 `;
 
@@ -270,13 +273,9 @@ const stylePopoverBase = css`
   position: absolute;
   z-index: ${ZIndex.Popover};
   min-height: 48px;
-  visibility: hidden;
-  opacity: 0;
-  transition: opacity ${Duration.Fade}, transform ${Duration.Fade};
+  transition: transform ${Duration.Fade};
 
   &[aria-hidden='false'] {
-    visibility: visible;
-    opacity: 1;
     transform: translate3d(0, 0, 0);
   }
 `;

--- a/packages/core/src/components/utils/Popover/index.tsx
+++ b/packages/core/src/components/utils/Popover/index.tsx
@@ -272,7 +272,7 @@ const stylePopoverBase = css`
   min-height: 48px;
   visibility: hidden;
   opacity: 0;
-  transition: visibility ${Duration.Fade}, opacity ${Duration.Fade}, transform ${Duration.Fade};
+  transition: opacity ${Duration.Fade}, transform ${Duration.Fade};
 
   &[aria-hidden='false'] {
     visibility: visible;

--- a/packages/core/src/components/utils/Popover/index.tsx
+++ b/packages/core/src/components/utils/Popover/index.tsx
@@ -273,9 +273,11 @@ const stylePopoverBase = css`
   position: absolute;
   z-index: ${ZIndex.Popover};
   min-height: 48px;
+  pointer-events: none;
   transition: transform ${Duration.Fade};
 
   &[aria-hidden='false'] {
+    pointer-events: auto;
     transform: translate3d(0, 0, 0);
   }
 `;

--- a/packages/core/src/hooks/useListBox/WithButton.story.tsx
+++ b/packages/core/src/hooks/useListBox/WithButton.story.tsx
@@ -1,7 +1,8 @@
 import { css } from '@linaria/core';
 import { useState } from 'react';
 import { useListBox } from '.';
-import { IconButton } from '../../components/inputs/IconButton';
+import { Icon } from '../../components/dataDisplay/Icon';
+import { Button } from '../../components/inputs/Button';
 import { FontSize } from '../../constants/Style';
 import { cssVar, gutter } from '../../helpers/Style';
 
@@ -22,16 +23,21 @@ export const Story = () => {
       <pre>
         <code>{JSON.stringify(value, null, 2)}</code>
       </pre>
+
       <hr />
-      <IconButton
-        name="list"
+
+      <Button
         ref={triggerProps.ref}
         onKeyDown={triggerProps.onKeyDown}
         onClick={triggerProps.onClick}
         tabIndex={triggerProps.tabIndex}
-        ariaHaspopup={triggerProps['aria-haspopup'] as any}
-        ariaExpanded={triggerProps['aria-expanded'] as any}
-      />
+        ariaHaspopup={triggerProps['aria-haspopup']}
+        ariaExpanded={triggerProps['aria-expanded']}
+      >
+        Open
+        <Icon name="angle-bottom" />
+      </Button>
+
       <ul className={styleMenu} role="menu" aria-hidden={!active}>
         {menuItems.map((item, index) => (
           <li key={item}>

--- a/packages/core/src/hooks/useListBox/WithIconButton.story.tsx
+++ b/packages/core/src/hooks/useListBox/WithIconButton.story.tsx
@@ -1,8 +1,7 @@
 import { css } from '@linaria/core';
 import { useState } from 'react';
 import { useListBox } from '.';
-import { Icon } from '../../components/dataDisplay/Icon';
-import { Button } from '../../components/inputs/Button';
+import { IconButton } from '../../components/inputs/IconButton';
 import { FontSize } from '../../constants/Style';
 import { cssVar, gutter } from '../../helpers/Style';
 
@@ -23,21 +22,16 @@ export const Story = () => {
       <pre>
         <code>{JSON.stringify(value, null, 2)}</code>
       </pre>
-
       <hr />
-
-      <Button
+      <IconButton
+        name="list"
         ref={triggerProps.ref}
         onKeyDown={triggerProps.onKeyDown}
         onClick={triggerProps.onClick}
         tabIndex={triggerProps.tabIndex}
-        ariaHaspopup={triggerProps['aria-haspopup']}
-        ariaExpanded={triggerProps['aria-expanded']}
-      >
-        Open
-        <Icon name="angle-bottom" />
-      </Button>
-
+        ariaHaspopup={triggerProps['aria-haspopup'] as any}
+        ariaExpanded={triggerProps['aria-expanded'] as any}
+      />
       <ul className={styleMenu} role="menu" aria-hidden={!active}>
         {menuItems.map((item, index) => (
           <li key={item}>

--- a/packages/core/src/hooks/useListBox/WithPopover.story.tsx
+++ b/packages/core/src/hooks/useListBox/WithPopover.story.tsx
@@ -1,6 +1,7 @@
 import { css } from '@linaria/core';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useListBox } from '.';
+import { Popover } from '../../components/utils/Popover';
 import { FontSize } from '../../constants/Style';
 import { cssVar, gutter } from '../../helpers/Style';
 
@@ -10,6 +11,8 @@ export const Story = () => {
   const { itemProps, active, setActive, triggerProps } = useListBox(menuItems.length);
 
   const [value, setValue] = useState('');
+
+  const id = useId();
 
   const handleSelect = (value: string) => {
     setValue(value);
@@ -23,6 +26,7 @@ export const Story = () => {
       </pre>
       <hr />
       <button
+        id={id}
         ref={triggerProps.ref}
         onKeyDown={triggerProps.onKeyDown}
         onClick={triggerProps.onClick}
@@ -33,28 +37,29 @@ export const Story = () => {
       >
         Open
       </button>
-      <ul className={styleMenu} role="menu" aria-hidden={!active}>
-        {menuItems.map((item, index) => (
-          <li key={item}>
-            <button
-              className={styleMenuItem}
-              onClick={() => handleSelect(item)}
-              onKeyDown={itemProps[index].onKeyDown}
-              tabIndex={itemProps[index].tabIndex}
-              role={itemProps[index].role}
-              ref={itemProps[index].ref}
-            >
-              {item}
-            </button>
-          </li>
-        ))}
-      </ul>
+      <Popover targetId={id} visible={active} alignment="start">
+        <ul className={styleMenu} role="menu" aria-hidden={!active}>
+          {menuItems.map((item, index) => (
+            <li key={item}>
+              <button
+                className={styleMenuItem}
+                onClick={() => handleSelect(item)}
+                onKeyDown={itemProps[index].onKeyDown}
+                tabIndex={itemProps[index].tabIndex}
+                role={itemProps[index].role}
+                ref={itemProps[index].ref}
+              >
+                {item}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </Popover>
     </>
   );
 };
 
 const styleMenu = css`
-  display: none;
   width: 240px;
   max-height: 120px;
   padding: ${gutter(2)} 0;
@@ -62,10 +67,6 @@ const styleMenu = css`
   font-size: ${FontSize.Regular};
   background-color: ${cssVar('TexturePaper')};
   box-shadow: ${cssVar('ShadowDialog')};
-
-  &[aria-hidden='false'] {
-    display: block;
-  }
 
   > :not(:first-child) {
     border-top: 1px solid ${cssVar('LineLight')};


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

`useListBox` の Menu 要素ラッパーとして `Popover` を使うと、 Menu 表示時に `menuitem` にフォーカスが当たらなくなる不具合がある。これを解消するのが目的。

### 何を変更したのか

<!-- このPRで何を変更をしたかの概要を記述 -->
`Popover` の表示・非表示のロジックを見直した。これにより `useListBox` と組み合わせても期待通りにフォーカスが当たるようになる。この挙動は `/hooks/useListBox/WithPopover.story.tsx` で確認できる。

### 技術的にはどこがポイントか

<!-- レビュワーにわかるように、技術的視線での変更概要説明 -->

表示・非表示の表現に CSS の `visibility` を使うのをやめ、 `opacity` のみを使うようにした。 `visibility` が `hidden` だとフォーカスを当てられず期待通りの挙動を得られない。 `opacity` を `0` にするだけならフォーカスを当てられる。ただし非活性中も各種 DOM イベントは有効のままのため、 `opacity` と併せて `pointer-events` を制御している。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

`/hooks/useListBox/WithButton.story.tsx` と `/hooks/useListBox/WithIconButton.story.tsx` の中身が逆になっていたのを修正した。

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
