### PR TITLE
preview の viewport を切り替える機能を実装する

### DIFF
--- a/packages/catalog/src/components/Layout/index.tsx
+++ b/packages/catalog/src/components/Layout/index.tsx
@@ -83,6 +83,7 @@ const styleNavigationWrapperBase = css`
   left: 0;
   z-index: 1;
   height: 100dvh;
+  border-right: 1px solid ${cssVar('LineLight')};
   transition: left ${Duration.Fade} ${Easing.Enter} ${delayTime}ms, width ${Duration.Fade} ${delayTime}ms,
     padding-right ${Duration.Fade} ${delayTime}ms, box-shadow ${Duration.Fade};
 `;

--- a/packages/catalog/src/components/Navigation/index.tsx
+++ b/packages/catalog/src/components/Navigation/index.tsx
@@ -93,7 +93,6 @@ const styleBase = css`
   height: 100%;
   overflow-y: auto;
   background-color: ${cssVar('TextureBody')};
-  border-right: 1px solid ${cssVar('LineNeutral')};
 `;
 
 const styleMasthead = css`

--- a/packages/catalog/src/pages/StoryPage/ToolbarButton.tsx
+++ b/packages/catalog/src/pages/StoryPage/ToolbarButton.tsx
@@ -58,8 +58,6 @@ export const ToolbarButton = forwardRef(
 
 const styleBase = css`
   display: inline-flex;
-  gap: ${gutter(2)};
-  place-content: center;
   align-items: center;
   padding: ${gutter(0.5)};
   font-size: ${FontSize.Tiny};

--- a/packages/catalog/src/pages/StoryPage/ToolbarButton.tsx
+++ b/packages/catalog/src/pages/StoryPage/ToolbarButton.tsx
@@ -1,0 +1,87 @@
+import { FontSize, IconSize } from '@learn-react/core/constants/Style';
+import { cssVar, gutter, square } from '@learn-react/core/helpers/Style';
+import { css, cx } from '@linaria/core';
+import type { AriaAttributes, ButtonHTMLAttributes, ForwardedRef, MouseEvent, ReactNode } from 'react';
+import { forwardRef } from 'react';
+
+type Props = {
+  children: ReactNode;
+  id?: string;
+  /**
+   * @default false
+   */
+  active?: boolean;
+} & XOR<
+  {
+    tabIndex?: ButtonHTMLAttributes<HTMLButtonElement>['tabIndex'];
+    onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+    /**
+     * メニューやダイアログなど、要素によって起動されるインタラクティブなポップアップ要素の有無と種類を示します。
+     */
+    ariaHaspopup?: AriaAttributes['aria-haspopup'];
+    /**
+     * 要素、またはそれが制御する別のグループ化要素が現在展開されているか、または折りたたまれているかを示します。
+     */
+    ariaExpanded?: AriaAttributes['aria-expanded'];
+  },
+  {
+    noop: true;
+  }
+>;
+
+export const ToolbarButton = forwardRef(
+  (
+    { children, id, active = false, tabIndex, onClick, ariaHaspopup, ariaExpanded, noop }: Props,
+    ref: ForwardedRef<HTMLSpanElement | HTMLButtonElement>,
+  ) => {
+    const styleButton = cx(styleBase, active && styleActive);
+
+    return noop ? (
+      <span ref={ref} id={id} className={styleButton}>
+        {children}
+      </span>
+    ) : (
+      <button
+        ref={ref as ForwardedRef<HTMLButtonElement>}
+        id={id}
+        className={styleButton}
+        tabIndex={tabIndex}
+        onClick={onClick}
+        aria-haspopup={ariaHaspopup}
+        aria-expanded={ariaExpanded}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+const styleBase = css`
+  display: inline-flex;
+  gap: ${gutter(2)};
+  place-content: center;
+  align-items: center;
+  padding: ${gutter(0.5)};
+  font-size: ${FontSize.Tiny};
+  color: white;
+  cursor: pointer;
+  user-select: none;
+  background-color: ${cssVar('ThemePrimaryDark')};
+  border: none;
+  opacity: 0.8;
+  appearance: none;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  > svg {
+    ${square(IconSize.Regular)}
+    fill: white;
+  }
+`;
+
+const styleActive = css`
+  background-color: ${cssVar('ThemePrimaryDarker')};
+  opacity: 1;
+`;

--- a/packages/catalog/src/pages/StoryPage/VO.ts
+++ b/packages/catalog/src/pages/StoryPage/VO.ts
@@ -3,5 +3,44 @@ export const Layout = {
   Vertical: 'vertical',
   Zen: 'zen',
 } as const;
-
 export type Layout = ValueOf<typeof Layout>;
+
+export const DeviceSize = {
+  unset: {
+    width: undefined,
+    height: undefined,
+  },
+  'iPhone 6/7/8': {
+    width: 375,
+    height: 667,
+  },
+  'iPhone 6/7/8/ Plus': {
+    width: 414,
+    height: 736,
+  },
+  'iPhone X': {
+    width: 375,
+    height: 812,
+  },
+  'iPhone XR': {
+    width: 414,
+    height: 896,
+  },
+  'iPhone 12 Pro': {
+    width: 390,
+    height: 844,
+  },
+  'iPad mini': {
+    width: 768,
+    height: 1024,
+  },
+  'iPad Air': {
+    width: 820,
+    height: 1180,
+  },
+  'iPad Pro': {
+    width: 1024,
+    height: 1366,
+  },
+} as const;
+export type DeviceSize = ValueOf<typeof DeviceSize>;

--- a/packages/catalog/src/pages/StoryPage/ViewportSwitch.tsx
+++ b/packages/catalog/src/pages/StoryPage/ViewportSwitch.tsx
@@ -1,0 +1,116 @@
+import { Icon } from '@learn-react/core/components/dataDisplay/Icon';
+import { Tooltip } from '@learn-react/core/components/dataDisplay/Tooltip';
+import { Card } from '@learn-react/core/components/surfaces/Card';
+import { Popover } from '@learn-react/core/components/utils/Popover';
+import { Duration, FontSize } from '@learn-react/core/constants/Style';
+import { cssVar, gutter } from '@learn-react/core/helpers/Style';
+import { nonNull } from '@learn-react/core/helpers/Type';
+import { useListBox } from '@learn-react/core/hooks/useListBox';
+import { css, cx } from '@linaria/core';
+import { useId, useState } from 'react';
+import { ToolbarButton } from './ToolbarButton';
+import { DeviceSize } from './VO';
+
+type Props = {
+  onChange: (value: DeviceSize) => void;
+};
+
+export const ViewportSwitch = ({ onChange }: Props) => {
+  const [selectedKey, setSelectedKey] = useState<keyof typeof DeviceSize>('unset');
+
+  const { itemProps, active, setActive, triggerProps } = useListBox(Object.keys(DeviceSize).length);
+
+  const id = useId();
+
+  const handleSelect = (key: keyof typeof DeviceSize, value: DeviceSize) => {
+    setActive(false);
+    setSelectedKey(key);
+    onChange(value);
+  };
+
+  return (
+    <>
+      <ToolbarButton
+        ref={triggerProps.ref}
+        id={id}
+        onClick={triggerProps.onClick}
+        tabIndex={triggerProps.tabIndex}
+        ariaExpanded={triggerProps['aria-expanded']}
+        ariaHaspopup={triggerProps['aria-haspopup']}
+        active={selectedKey !== 'unset'}
+      >
+        <Icon name="devices" />
+      </ToolbarButton>
+
+      <Popover targetId={id} visible={active} alignment="end">
+        <Card shadow="floating">
+          <ul role="menu">
+            {Object.entries(DeviceSize).map(([key, value], index) => (
+              <li key={key}>
+                <button
+                  ref={itemProps[index].ref}
+                  onClick={() => handleSelect(key as keyof typeof DeviceSize, value)}
+                  onKeyDown={itemProps[index].onKeyDown}
+                  tabIndex={itemProps[index].tabIndex}
+                  role={itemProps[index].role}
+                  className={cx(styleMenuItem, key === selectedKey && styleMenuItemSelected)}
+                >
+                  {key}
+                  {Object.values(value).every(nonNull) ? (
+                    <span className={styleDisplayedValues}>
+                      <span>{value.width}</span>
+                      <span>x</span>
+                      <span>{value.height}</span>
+                    </span>
+                  ) : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      </Popover>
+
+      <Tooltip targetId={id}>Change the viewport</Tooltip>
+    </>
+  );
+};
+
+const styleMenuItem = css`
+  display: flex;
+  gap: ${gutter(4)};
+  justify-content: space-between;
+  width: 100%;
+  padding: ${gutter(1)} ${gutter(4)};
+  font-size: ${FontSize.Small};
+  font-weight: bold;
+  color: ${cssVar('TextNeutral')};
+  text-align: left;
+  cursor: pointer;
+  background-color: transparent;
+  border: none;
+  transition: background-color ${Duration.Fade};
+  appearance: none;
+
+  &:hover {
+    color: white;
+    background-color: ${cssVar('ThemePrimaryDark')};
+  }
+
+  &:focus {
+    color: white;
+    background-color: ${cssVar('ThemePrimaryNeutral')};
+  }
+`;
+
+const styleMenuItemSelected = css`
+  color: white;
+  cursor: default;
+  background-color: ${cssVar('ThemePrimaryNeutral')};
+`;
+
+const styleDisplayedValues = css`
+  display: flex;
+  gap: ${gutter(1)};
+  font-size: ${FontSize.Tiny};
+  font-weight: normal;
+`;

--- a/packages/catalog/src/pages/StoryPage/index.tsx
+++ b/packages/catalog/src/pages/StoryPage/index.tsx
@@ -65,14 +65,15 @@ const Presentation = () => {
             maxSize="80%"
             orientation={layoutConfig !== Layout.Zen ? layoutConfig : Layout.Horizontal}
           >
-            <iframe
-              // story page 切替時に前回の preview が一瞬だが残ってしまうのを回避するために
-              // 強制的に再マウントしてゼロからレンダリングさせている。
-              key={storyId}
-              src={`/preview.html?storyId=${storyId}`}
-              title={storyKeys.slice().reverse().join(' | ')}
-              className={stylePreview}
-            />
+            <div className={stylePreview}>
+              <iframe
+                // story page 切替時に前回の preview が一瞬だが残ってしまうのを回避するために
+                // 強制的に再マウントしてゼロからレンダリングさせている。
+                key={storyId}
+                src={`/preview.html?storyId=${storyId}`}
+                title={storyKeys.slice().reverse().join(' | ')}
+              />
+            </div>
 
             {layoutConfig !== Layout.Zen ? (
               <aside className={styleCodeBlock}>
@@ -144,10 +145,25 @@ const styleBody = css`
 `;
 
 const stylePreview = css`
-  display: block;
+  display: grid;
+  /* place-content: center; */
   width: 100%;
   height: 100%;
-  border: none;
+  background-color: ${cssVar('TextureBackdrop')};
+  background-image: linear-gradient(rgba(128, 128, 128, 0.1) 2px, transparent 2px),
+    linear-gradient(90deg, rgba(128, 128, 128, 0.1) 2px, transparent 2px),
+    linear-gradient(rgba(128, 128, 128, 0.1) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(128, 128, 128, 0.1) 1px, transparent 1px);
+  background-position: -2px -2px, -2px -2px, -1px -1px, -1px -1px;
+  background-size: 100px 100px, 100px 100px, 20px 20px, 20px 20px;
+
+  > iframe {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: none;
+    box-shadow: ${cssVar('ShadowDialog')};
+  }
 `;
 
 const styleCodeBlock = css`

--- a/packages/core/src/components/utils/Popover/index.tsx
+++ b/packages/core/src/components/utils/Popover/index.tsx
@@ -259,6 +259,7 @@ const styleBase = css`
   right: 0;
   bottom: 0;
   left: 0;
+  z-index: ${ZIndex.Popover - 1};
   pointer-events: none;
   opacity: 0;
   transition: opacity ${Duration.Fade};

--- a/packages/core/src/helpers/Style.ts
+++ b/packages/core/src/helpers/Style.ts
@@ -200,6 +200,7 @@ export function applyGlobalStyle() {
         font-family: ${FontFamily.Default};
         font-weight: 500;
         font-feature-settings: palt 1;
+        background-color: ${cssVar('TextureBody')};
       }
       body,
       h1,

--- a/packages/core/src/helpers/Type.test.ts
+++ b/packages/core/src/helpers/Type.test.ts
@@ -1,0 +1,9 @@
+import { nonNull } from './Type';
+
+describe('Type.ts', () => {
+  describe(nonNull.name, () => {
+    test(`['🍎', undefined, '🍊', null, '🍇'].filter(nonNull) === ['🍎', '🍊', '🍇']`, () => {
+      expect(['🍎', undefined, '🍊', null, '🍇'].filter(nonNull)).toEqual(['🍎', '🍊', '🍇']);
+    });
+  });
+});

--- a/packages/core/src/helpers/Type.ts
+++ b/packages/core/src/helpers/Type.ts
@@ -1,0 +1,16 @@
+/**
+ * 渡された値が存在するものかどうかを判定します。
+ *
+ * Array.prototype.filter と組み合わせると、配列から `null` と `undefined` を取り除くことができます。
+ *
+ * @example
+ * ```ts
+ * const ary = ['🍎', undefined, '🍊', null, '🍇'];
+ *
+ * const fruits = ary.filter(nonNull);
+ * // ['🍎', '🍊', '🍇'];
+ * ```
+ */
+export function nonNull<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}

--- a/packages/icon/src/devices.svg
+++ b/packages/icon/src/devices.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <style>.cls-1{fill:#474a5e;}</style>
+  </defs>
+  <path class="cls-1" d="M4 6h18V4H4c-1.1 0-2 .9-2 2v11H0v3h14v-3H4V6zm19 2h-6c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h6c.55 0 1-.45 1-1V9c0-.55-.45-1-1-1zm-1 9h-4v-7h4v7z"/>
+</svg>


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

Storybook, Ladle, react-cosmos のように preview の viewport を様々なでデバイスサイズに切り替えられるようにするため。

### 何を変更したのか

<!-- このPRで何を変更をしたかの概要を記述 -->
- preview の viewport を切り替える機能を追加実装した。
- 変数が truly かどうかを検証する `nonNull` 関数を実装した。

### 技術的にはどこがポイントか

<!-- レビュワーにわかるように、技術的視線での変更概要説明 -->

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

- #806 

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
