### PR TITLE
eslint-plugin-import のルール設定をアップデートする

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -40,6 +40,7 @@ module.exports = {
     '@typescript-eslint/switch-exhaustiveness-check': ['error'],
     'arrow-body-style': ['error', 'as-needed'],
     'func-names': ['error'],
+    'import/no-default-export': ['error'],
     'lines-between-class-members': [
       'error',
       'always',
@@ -100,9 +101,9 @@ module.exports = {
     '@typescript-eslint/no-use-before-define': ['off'],
     'class-methods-use-this': ['off'],
     'consistent-return': ['off'], // TypeScript のフロー解析を考慮できないため false positive が発生する
-    'import/extensions': ['off'],
-    'import/no-extraneous-dependencies': ['off'],
-    'import/no-unresolved': ['off'],
+    'import/extensions': ['off'], // import path に拡張子を含めることを強制するため無効化する。
+    'import/no-extraneous-dependencies': ['off'], // プロジェクトルートにある node モジュールの import を指摘するため無効化する。
+    'import/no-unresolved': ['off'], // tsconfig にて設定した alias path を認識できないため無効化する。
     'import/prefer-default-export': ['off'],
     'jsx-a11y/accessible-emoji': ['off'],
     'jsx-a11y/control-has-associated-label': ['off'],
@@ -113,7 +114,6 @@ module.exports = {
     'jsx-a11y/mouse-events-have-key-events': ['off'],
     'jsx-a11y/no-autofocus': ['off'],
     'jsx-a11y/no-noninteractive-element-interactions': ['off'],
-    // 'jsx-a11y/no-static-element-interactions': ['off'],
     'default-case': ['off'],
     'global-require': ['off'],
     'max-classes-per-file': ['off'],
@@ -139,6 +139,12 @@ module.exports = {
   },
   overrides: [
     {
+      files: ['./**/ambience.d.ts'],
+      rules: {
+        'import/no-default-export': ['off'],
+      },
+    },
+    {
       files: ['./**/stores/**/*.ts'],
       rules: {
         'react-hooks/rules-of-hooks': ['off'],
@@ -148,6 +154,8 @@ module.exports = {
       files: ['./**/vite.config.ts'],
       rules: {
         'no-underscore-dangle': ['off'],
+        'import/no-default-export': ['off'],
+        'import/no-relative-packages': ['off'], // サブパッケージを越境した import を指摘するため無効化する。
       },
     },
     {
@@ -155,8 +163,8 @@ module.exports = {
       rules: {
         '@typescript-eslint/ban-ts-comment': ['off'],
         '@typescript-eslint/no-var-requires': ['off'],
-        'import/no-relative-packages': ['off'],
         'no-underscore-dangle': ['off'],
+        'import/no-default-export': ['off'],
       },
     },
     {

--- a/package.json
+++ b/package.json
@@ -95,9 +95,9 @@
   "lint-staged": {
     "packages/**/src/**/*.{ts,tsx}": [
       "cspell",
-      "prettier -c -w",
-      "eslint -c .eslintrc.cjs --fix",
-      "stylelint --cache --fix"
+      "prettier -c",
+      "eslint -c .eslintrc.cjs",
+      "stylelint --cache"
     ]
   }
 }

--- a/packages/core/src/components/inputs/ComboBox/index.story.tsx
+++ b/packages/core/src/components/inputs/ComboBox/index.story.tsx
@@ -24,7 +24,7 @@ export const Story = () => {
 
   const [state1, setState1] = useState<Option | null>(options[0]);
 
-  const handleChange1 = (item: typeof options[number] | null) => {
+  const handleChange1 = (item: (typeof options)[number] | null) => {
     setState1(item);
   };
 

--- a/packages/try/src/Suspense2/index.story.tsx
+++ b/packages/try/src/Suspense2/index.story.tsx
@@ -8,7 +8,7 @@ import { RenderAsYouFetch } from './RenderAsYouFetch';
 
 const DemoList = ['DataFetching1', 'DataFetching2', 'RenderAsYouFetch'] as const;
 
-type Demo = typeof DemoList[number];
+type Demo = (typeof DemoList)[number];
 
 export const Story = () => {
   const [demo, setDemo] = useState<Demo>('DataFetching1');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "types": ["vite/client", "jest"],
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
     "removeComments": false,
     "strict": true,
     "noUnusedLocals": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7915,13 +7915,13 @@ __metadata:
   linkType: hard
 
 "json5@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "json5@npm:1.0.1"
+  version: 1.0.2
+  resolution: "json5@npm:1.0.2"
   dependencies:
     minimist: ^1.2.0
   bin:
     json5: lib/cli.js
-  checksum: e76ea23dbb8fc1348c143da628134a98adf4c5a4e8ea2adaa74a80c455fc2cdf0e2e13e6398ef819bfe92306b610ebb2002668ed9fc1af386d593691ef346fc3
+  checksum: 866458a8c58a95a49bef3adba929c625e82532bcff1fe93f01d29cb02cac7c3fe1f4b79951b7792c2da9de0b32871a8401a6e3c5b36778ad852bf5b8a61165d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->
`eslint-plugin-import` のルール設定が大雑把だったため。

### 何を変更したのか

<!-- このPRで何を変更をしたかの概要を記述 -->
- default export をライブラリが要求する場面を除き禁止するようにした。
- eslint-plugin-import　のうち無効化しているルールの理由を加筆した。

上記に加えて下記の修正も実施した。

- pre-commit での autofix をやめた。
- tsc がファイル名の大文字・小文字を区別するように設定した。

### 技術的にはどこがポイントか

<!-- レビュワーにわかるように、技術的視線での変更概要説明 -->

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

当初は eslint-plugin-import そのものを撤去する目的で検証していたが、import 句のソート以外でも使うことが判明したため、残しつつ設定を見直すことにした。

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
