### PR TITLE
隣接するサブパッケージ名を dependencies から除去する

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -134,7 +134,7 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': ['off'],
     '@typescript-eslint/no-unsafe-call': ['off'], // tsconfig にて設定した alias path を認識できないため無効化する。
     '@typescript-eslint/no-unsafe-argument': ['off'], // tsconfig にて設定した alias path を認識できないため無効化する。
-    '@typescript-eslint/no-unsafe-assignment': ['off'], // tsconfig にて設定した alias path を認識できないため無効化する。
+    '@typescript-eslint/no-unsafe-assignment': ['off'], // tsconfig にて設定した alias path や画像ファイルを正しく認識できず any 型と誤認するため無効化する。
     '@typescript-eslint/no-unsafe-member-access': ['off'], // tsconfig にて設定した alias path を認識できないため無効化する。
     '@typescript-eslint/no-unsafe-return': ['off'], // tsconfig にて設定した alias path を認識できないため無効化する。
     '@typescript-eslint/no-use-before-define': ['off'],

--- a/cspell.json
+++ b/cspell.json
@@ -3,7 +3,8 @@
     "**/node_modules/**",
     "./packages/icon/dist/*",
     "./packages/catalog/src/constants/StorySpec.ts",
-    "./packages/catalog/src/constants/Stories.ts"
+    "./packages/catalog/src/constants/Stories.ts",
+    "./yarn.lock"
   ],
   "words": [
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ",

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -2,11 +2,6 @@
   "name": "@learn-react/catalog",
   "version": "1.0.0",
   "license": "UNLICENSED",
-  "dependencies": {
-    "@learn-react/core": "1.0.0",
-    "@learn-react/icon": "1.0.0",
-    "@learn-react/try": "1.0.0"
-  },
   "scripts": {
     "generate": "node ./bin/codegen.mjs",
     "develop": "   run -T vite serve",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,8 +5,5 @@
   "type": "module",
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules run --top-level jest"
-  },
-  "dependencies": {
-    "@learn-react/icon": "1.0.0"
   }
 }

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -5,9 +5,6 @@
   "keywords": [
     "react-router-dom"
   ],
-  "dependencies": {
-    "@learn-react/core": "1.0.0"
-  },
   "scripts": {
     "develop": "   run -T vite serve",
     "type-check": "run -T tsc --noEmit",

--- a/packages/statement/package.json
+++ b/packages/statement/package.json
@@ -8,10 +8,6 @@
     "unstated-next",
     "constate"
   ],
-  "dependencies": {
-    "@learn-react/core": "1.0.0",
-    "@learn-react/icon": "1.0.0"
-  },
   "scripts": {
     "develop": "   run -T vite serve",
     "type-check": "run -T tsc --noEmit",

--- a/packages/try/package.json
+++ b/packages/try/package.json
@@ -1,8 +1,5 @@
 {
   "name": "@learn-react/try",
   "version": "1.0.0",
-  "license": "UNLICENSED",
-  "dependencies": {
-    "@learn-react/core": "1.0.0"
-  }
+  "license": "UNLICENSED"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,18 +2863,12 @@ __metadata:
 "@learn-react/catalog@workspace:packages/catalog":
   version: 0.0.0-use.local
   resolution: "@learn-react/catalog@workspace:packages/catalog"
-  dependencies:
-    "@learn-react/core": 1.0.0
-    "@learn-react/icon": 1.0.0
-    "@learn-react/try": 1.0.0
   languageName: unknown
   linkType: soft
 
-"@learn-react/core@1.0.0, @learn-react/core@workspace:packages/core":
+"@learn-react/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@learn-react/core@workspace:packages/core"
-  dependencies:
-    "@learn-react/icon": 1.0.0
   languageName: unknown
   linkType: soft
 
@@ -2890,7 +2884,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@learn-react/icon@1.0.0, @learn-react/icon@workspace:packages/icon":
+"@learn-react/icon@workspace:packages/icon":
   version: 0.0.0-use.local
   resolution: "@learn-react/icon@workspace:packages/icon"
   languageName: unknown
@@ -2899,25 +2893,18 @@ __metadata:
 "@learn-react/routing@workspace:packages/routing":
   version: 0.0.0-use.local
   resolution: "@learn-react/routing@workspace:packages/routing"
-  dependencies:
-    "@learn-react/core": 1.0.0
   languageName: unknown
   linkType: soft
 
 "@learn-react/statement@workspace:packages/statement":
   version: 0.0.0-use.local
   resolution: "@learn-react/statement@workspace:packages/statement"
-  dependencies:
-    "@learn-react/core": 1.0.0
-    "@learn-react/icon": 1.0.0
   languageName: unknown
   linkType: soft
 
-"@learn-react/try@1.0.0, @learn-react/try@workspace:packages/try":
+"@learn-react/try@workspace:packages/try":
   version: 0.0.0-use.local
   resolution: "@learn-react/try@workspace:packages/try"
-  dependencies:
-    "@learn-react/core": 1.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->
- dependencies に含めずとも IDE, ビルド共に正常に動作するため。

### 何を変更したのか

<!-- このPRで何を変更をしたかの概要を記述 -->

- 各サブパッケージの `package.json` > `dependencies` から隣接サブパッケージの依存指定を除去した。
- `yarn.lock` を code spell checker の対象外とした。
- `@typescript-eslint/no-unsafe-assignment` を無効化した。

### 技術的にはどこがポイントか

<!-- レビュワーにわかるように、技術的視線での変更概要説明 -->

ビルドを通すだけなら `dependencies` への記載は不要なのだが、IDE が不正なモジュールと解釈してエラーを出してしまうため、これを回避するために記述していた。
しかし改めて検証してみると、これをせずともエラーと表記されなくなっていた。VSCode のアップデートによっていつの間にか解消されたのか、当時の設計に別の不備があったのか真相は不明だが、少なくとも現状は不要と判断したため、除去することにした。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
