### PR TITLE
:cyclone: vite.config ファイルから `__dirname` を生成するポリフィルコードを削除する

### DIFF
--- a/packages/catalog/vite.config.ts
+++ b/packages/catalog/vite.config.ts
@@ -1,8 +1,6 @@
-import { dirname, resolve } from 'path';
+import { resolve } from 'path';
 import { defineConfig, loadEnv, type UserConfig } from 'vite';
 import { createUserConfig } from '../../builder/vite';
-
-const __dirname = dirname(new URL(import.meta.url).pathname);
 
 export default defineConfig(({ mode }): UserConfig => {
   const projectRootPath = resolve(__dirname, '../../');

--- a/packages/routing/vite.config.ts
+++ b/packages/routing/vite.config.ts
@@ -1,8 +1,5 @@
-import { dirname } from 'path';
 import { defineConfig, type UserConfig } from 'vite';
 import { createUserConfig } from '../../builder/vite';
-
-const __dirname = dirname(new URL(import.meta.url).pathname);
 
 export default defineConfig(({ mode }): UserConfig => {
   console.info({ mode });

--- a/packages/statement/vite.config.ts
+++ b/packages/statement/vite.config.ts
@@ -1,8 +1,5 @@
-import { dirname } from 'path';
 import { defineConfig, type UserConfig } from 'vite';
 import { createUserConfig } from '../../builder/vite';
-
-const __dirname = dirname(new URL(import.meta.url).pathname);
 
 export default defineConfig(({ mode }): UserConfig => {
   console.info({ mode });


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

- 不要なハックのため。

### 何を変更したのか

<!-- このPRで何を変更をしたかの概要を記述 -->

- `vite.config.ts` から `__dirname` を生成するワークアラウンドコードを削除した。
  - ESM ベースの `*.js` では引き続き必要なため残している。

### 技術的にはどこがポイントか

<!-- レビュワーにわかるように、技術的視線での変更概要説明 -->

TypeScript の場合 `@types/node` がインストールされていればコードベースが ESM であっても `__dirname` は利用可能。したがって自前でポリフィルコードを書く必要はない。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
