### PR TITLE
CSS-in-JS を Linaria から Emotion に戻す

### DIFF
--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -1,10 +1,5 @@
 module.exports = {
-  extends: [
-    'stylelint-config-recommended',
-    'stylelint-config-standard',
-    'stylelint-config-recess-order',
-    '@linaria/stylelint',
-  ],
+  extends: ['stylelint-config-recommended', 'stylelint-config-standard', 'stylelint-config-recess-order'],
   ignoreFiles: ['**/node_modules/**'],
   customSyntax: '@stylelint/postcss-css-in-js',
   rules: {

--- a/builder/vite.ts
+++ b/builder/vite.ts
@@ -1,4 +1,3 @@
-import linaria from '@linaria/rollup';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 import type { BuildOptions, UserConfig } from 'vite';
@@ -49,23 +48,6 @@ export function createUserConfig({ basePath, port = 3000, define = {}, build = {
           parserOpts: {
             plugins: ['decorators-legacy', 'classProperties'],
           },
-        },
-      }),
-      linaria({
-        sourceMap: true,
-        babelOptions: {
-          plugins: [
-            // linaria にエイリアスパスを認識させるための措置。
-            [
-              'module-resolver',
-              {
-                alias,
-              },
-            ],
-          ],
-          // パースエラー回避のための措置。
-          // linaria でのスタイル定義内に何かしら型情報が入り込む場合はこの設定が必要となる。
-          presets: ['@babel/preset-typescript'],
         },
       }),
     ],

--- a/package.json
+++ b/package.json
@@ -24,11 +24,7 @@
     "format": "prettier -c -w packages/**/*.{ts,tsx}; eslint -c .eslintrc.cjs packages/**/*.{ts,tsx} --fix; stylelint packages/**/*.{ts,tsx} --fix"
   },
   "devDependencies": {
-    "@babel/preset-typescript": "7.21.0",
     "@commitlint/cli": "17.4.4",
-    "@linaria/rollup": "3.0.0-beta.23",
-    "@linaria/shaker": "3.0.0-beta.23",
-    "@linaria/stylelint": "3.0.0-beta.23",
     "@stylelint/postcss-css-in-js": "0.38.0",
     "@types/jest": "29.4.0",
     "@types/node": "18.14.6",
@@ -38,8 +34,6 @@
     "@typescript-eslint/eslint-plugin": "5.54.1",
     "@typescript-eslint/parser": "5.54.1",
     "@vitejs/plugin-react": "3.1.0",
-    "babel-loader": "9.1.2",
-    "babel-plugin-module-resolver": "5.0.0",
     "cheerio": "1.0.0-rc.12",
     "chokidar": "3.5.3",
     "cspell": "6.28.0",
@@ -57,6 +51,7 @@
     "jest-environment-jsdom": "29.5.0",
     "lint-staged": "13.1.4",
     "npm-run-all": "4.1.5",
+    "postcss": "8.4.21",
     "postcss-syntax": "0.36.2",
     "prettier": "2.8.4",
     "prettier-plugin-organize-imports": "3.2.2",
@@ -75,7 +70,7 @@
     "yargs": "17.7.1"
   },
   "dependencies": {
-    "@linaria/core": "3.0.0-beta.22",
+    "@emotion/css": "11.10.6",
     "constate": "3.3.2",
     "csx": "10.0.2",
     "date-fns": "2.29.3",

--- a/packages/catalog/index.html
+++ b/packages/catalog/index.html
@@ -6,6 +6,10 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <meta name="description" content="This site lists React components and custom hooks developed by wakamsha." />
     <link rel="shortcut icon" href="/src/favicon-32x32.png" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/atom-one-dark.min.css"
+    />
     <title>Catalog | Learn React</title>
   </head>
 

--- a/packages/catalog/src/components/Layout/index.tsx
+++ b/packages/catalog/src/components/Layout/index.tsx
@@ -1,8 +1,8 @@
+import { css, cx } from '@emotion/css';
 import { IconButton } from '@learn-react/core/components/inputs/IconButton';
 import { Duration, Easing } from '@learn-react/core/constants/Style';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
 import { type IconName } from '@learn-react/icon';
-import { css, cx, type LinariaClassName } from '@linaria/core';
 import { useEffect, useState, type ReactNode } from 'react';
 import { Navigation } from '../Navigation';
 import { useLayoutConfig } from './useLayoutConfig';
@@ -60,7 +60,7 @@ const styleBaseBase = css`
   transition: padding-left ${Duration.Fade} ${Easing.Enter};
 `;
 
-const styleBase: Frozen<LayoutMode, LinariaClassName> = {
+const styleBase: Frozen<LayoutMode, string> = {
   [LayoutMode.Neutral]: cx(
     styleBaseBase,
     css`
@@ -86,7 +86,7 @@ const styleNavigationWrapperBase = css`
     padding-right ${Duration.Fade} ${delayTime}ms, box-shadow ${Duration.Fade};
 `;
 
-const styleNavigationWrapper: Frozen<LayoutMode, LinariaClassName> = {
+const styleNavigationWrapper: Frozen<LayoutMode, string> = {
   [LayoutMode.Neutral]: cx(
     styleNavigationWrapperBase,
     css`
@@ -118,7 +118,7 @@ const styleToggleButtonWrapperBase = css`
   transition: left ${Duration.Fade} ${Easing.Enter};
 `;
 
-const styleToggleButtonWrapper: Frozen<LayoutMode, LinariaClassName> = {
+const styleToggleButtonWrapper: Frozen<LayoutMode, string> = {
   [LayoutMode.Neutral]: cx(
     styleToggleButtonWrapperBase,
     css`

--- a/packages/catalog/src/components/Navigation/index.tsx
+++ b/packages/catalog/src/components/Navigation/index.tsx
@@ -1,8 +1,8 @@
+import { css } from '@emotion/css';
 import { Icon } from '@learn-react/core/components/dataDisplay/Icon';
 import { TextField } from '@learn-react/core/components/inputs/TextField';
 import { BorderRadius, Duration, FontFamily, FontSize, IconSize } from '@learn-react/core/constants/Style';
 import { cssVar, gutter, square } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useEffect, useMemo, useRef, useState, type FC, type RefObject } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { stories } from '../../constants/Stories';

--- a/packages/catalog/src/components/Preview.tsx
+++ b/packages/catalog/src/components/Preview.tsx
@@ -1,7 +1,7 @@
+import { css } from '@emotion/css';
 import { DocumentTitle } from '@learn-react/core/components/utils/DocumentTitle';
 import { BorderRadius, FontFamily, FontSize } from '@learn-react/core/constants/Style';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useStory } from '../hooks/useStory';
 
 export const Preview = () => {

--- a/packages/catalog/src/pages/IndexPage.tsx
+++ b/packages/catalog/src/pages/IndexPage.tsx
@@ -1,7 +1,7 @@
+import { css } from '@emotion/css';
 import { SplashBanner } from '@learn-react/core/components/surfaces/SplashBanner';
 import { DocumentTitle } from '@learn-react/core/components/utils/DocumentTitle';
 import { cssVar } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 
 export const IndexPage = () => (
   <>

--- a/packages/catalog/src/pages/StoryPage/CodeBlock.tsx
+++ b/packages/catalog/src/pages/StoryPage/CodeBlock.tsx
@@ -1,6 +1,6 @@
+import { css } from '@emotion/css';
 import { FontFamily, LineHeight } from '@learn-react/core/constants/Style';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import hljs from 'highlight.js';
 import { useEffect, useRef } from 'react';
 
@@ -17,19 +17,6 @@ export const CodeBlock = ({ children }: Props) => {
       hljs.highlightElement(ref.current);
     }
   });
-
-  useEffect(() => {
-    // html ファイルにハードコーディングすると `vite build` 時に Linaria が失敗するため、
-    // これを回避するため動的に `<link>` 要素を生成して挿入する。
-    if (!document.querySelector('link#highlight-theme')) {
-      const dom = document.createElement('link');
-      dom.rel = 'stylesheet';
-      dom.id = 'highlight-theme';
-      dom.href = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/atom-one-dark.min.css';
-
-      document.head.append(dom);
-    }
-  }, []);
 
   return (
     <pre className={styleBase}>

--- a/packages/catalog/src/pages/StoryPage/LayoutSwitch.tsx
+++ b/packages/catalog/src/pages/StoryPage/LayoutSwitch.tsx
@@ -1,5 +1,5 @@
+import { css, cx } from '@emotion/css';
 import { cssVar, gutter, square } from '@learn-react/core/helpers/Style';
-import { css, cx } from '@linaria/core';
 import { type MouseEvent } from 'react';
 import { LayoutConfigContainer } from './LayoutConfigContainer';
 import { Layout } from './VO';

--- a/packages/catalog/src/pages/StoryPage/ToolbarButton.tsx
+++ b/packages/catalog/src/pages/StoryPage/ToolbarButton.tsx
@@ -1,6 +1,6 @@
+import { css, cx } from '@emotion/css';
 import { FontSize, IconSize } from '@learn-react/core/constants/Style';
 import { cssVar, gutter, square } from '@learn-react/core/helpers/Style';
-import { css, cx } from '@linaria/core';
 import {
   forwardRef,
   type AriaAttributes,

--- a/packages/catalog/src/pages/StoryPage/ViewportSwitch.tsx
+++ b/packages/catalog/src/pages/StoryPage/ViewportSwitch.tsx
@@ -1,3 +1,4 @@
+import { css, cx } from '@emotion/css';
 import { Icon } from '@learn-react/core/components/dataDisplay/Icon';
 import { Tooltip } from '@learn-react/core/components/dataDisplay/Tooltip';
 import { Card } from '@learn-react/core/components/surfaces/Card';
@@ -6,7 +7,6 @@ import { Duration, FontSize } from '@learn-react/core/constants/Style';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
 import { nonNull } from '@learn-react/core/helpers/Type';
 import { useListBox } from '@learn-react/core/hooks/useListBox';
-import { css, cx } from '@linaria/core';
 import { useId, useState } from 'react';
 import { ToolbarButton } from './ToolbarButton';
 import { DeviceSize } from './VO';

--- a/packages/catalog/src/pages/StoryPage/index.tsx
+++ b/packages/catalog/src/pages/StoryPage/index.tsx
@@ -1,3 +1,4 @@
+import { css, cx } from '@emotion/css';
 import { Icon } from '@learn-react/core/components/dataDisplay/Icon';
 import { Tooltip } from '@learn-react/core/components/dataDisplay/Tooltip';
 import { DocumentTitle } from '@learn-react/core/components/utils/DocumentTitle';
@@ -5,7 +6,6 @@ import { SplitPane } from '@learn-react/core/components/utils/SplitPane';
 import { Duration, Easing, FontFamily, FontSize, LineHeight } from '@learn-react/core/constants/Style';
 import { cssVar, gutter, textEllipsis } from '@learn-react/core/helpers/Style';
 import { nonNull } from '@learn-react/core/helpers/Type';
-import { css, cx } from '@linaria/core';
 import { useId, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useStory } from '../../hooks/useStory';

--- a/packages/catalog/src/preview.tsx
+++ b/packages/catalog/src/preview.tsx
@@ -5,8 +5,13 @@
  * URL `/preview.html?storyId=foo_bar_baz` にアクセスすることでプレビューのみの表示も可能です。
  */
 
+import { applyGlobalStyle, applyResetStyle } from '@learn-react/core/helpers/Style';
 import { createRoot } from 'react-dom/client';
 import { Preview } from './components/Preview';
+
+applyResetStyle();
+
+applyGlobalStyle();
 
 const root = createRoot(document.getElementById('preview') as HTMLElement);
 root.render(<Preview />);

--- a/packages/core/src/components/dataDisplay/Icon/index.story.tsx
+++ b/packages/core/src/components/dataDisplay/Icon/index.story.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { iconElements, type IconName } from '@learn-react/icon';
-import { css } from '@linaria/core';
 import { Icon } from '.';
 import { FontSize } from '../../../constants/Style';
 import { cssVar, gutter, square } from '../../../helpers/Style';

--- a/packages/core/src/components/dataDisplay/PDFViewer/Page.tsx
+++ b/packages/core/src/components/dataDisplay/PDFViewer/Page.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import * as pdfjsLib from 'pdfjs-dist';
 import { type PDFPageProxy, type TextStyle } from 'pdfjs-dist/types/src/display/api';
 import { type PageViewport } from 'pdfjs-dist/types/src/display/display_utils';

--- a/packages/core/src/components/dataDisplay/PDFViewer/index.tsx
+++ b/packages/core/src/components/dataDisplay/PDFViewer/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import * as pdfjsLib from 'pdfjs-dist';
 import workerUrl from 'pdfjs-dist/build/pdf.worker.min.js?url';
 import { type PDFPageProxy } from 'pdfjs-dist/types/src/display/api';

--- a/packages/core/src/components/dataDisplay/Tooltip/index.story.tsx
+++ b/packages/core/src/components/dataDisplay/Tooltip/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useState } from 'react';
 import { Tooltip } from '.';
 import { FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/dataDisplay/Tooltip/index.tsx
+++ b/packages/core/src/components/dataDisplay/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { BorderRadius, Duration, FontSize, LineHeight, ZIndex } from '../../../constants/Style';

--- a/packages/core/src/components/feedback/Preloader/index.tsx
+++ b/packages/core/src/components/feedback/Preloader/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { cssVar } from '../../../helpers/Style';
 
 type Size = 'neutral' | 'button';

--- a/packages/core/src/components/feedback/Toast/Container.tsx
+++ b/packages/core/src/components/feedback/Toast/Container.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { createPortal } from 'react-dom';
 import { useToasts } from '.';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/feedback/Toast/Item.tsx
+++ b/packages/core/src/components/feedback/Toast/Item.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@linaria/core';
+import { css, cx } from '@emotion/css';
 import { useEffect, useState, type AnimationEvent, type ReactNode } from 'react';
 import { useRemoveToast, type Toast } from '.';
 import { Duration, Easing, FontSize, IconSize } from '../../../constants/Style';

--- a/packages/core/src/components/feedback/Toast/index.story.tsx
+++ b/packages/core/src/components/feedback/Toast/index.story.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { iconElements, type IconName } from '@learn-react/icon';
-import { css } from '@linaria/core';
 import { useMemo, useReducer, useState, type ChangeEvent } from 'react';
 import { ToastProvider, useAddToast, type Toast } from '.';
 import { FontSize, LineHeight } from '../../../constants/Style';

--- a/packages/core/src/components/feedback/ToastLegacy/Container.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy/Container.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { createPortal } from 'react-dom';
 import { type Toast } from '.';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/feedback/ToastLegacy/Item.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy/Item.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@linaria/core';
+import { css, cx } from '@emotion/css';
 import { useEffect, useState, type AnimationEvent, type ReactNode } from 'react';
 import { Toast } from '.';
 import { Duration, Easing, IconSize } from '../../../constants/Style';

--- a/packages/core/src/components/feedback/ToastLegacy/index.story.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy/index.story.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { iconElements, type IconName } from '@learn-react/icon';
-import { css } from '@linaria/core';
 import { useMemo, useReducer, useState, type ChangeEvent } from 'react';
 import { Toast } from '.';
 import { FontSize, LineHeight } from '../../../constants/Style';

--- a/packages/core/src/components/feedback/ToastLegacy2/Container.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy2/Container.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { createPortal } from 'react-dom';
 import { Toast } from '.';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/feedback/ToastLegacy2/Item.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy2/Item.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@linaria/core';
+import { css, cx } from '@emotion/css';
 import { useEffect, useState, type AnimationEvent, type ReactNode } from 'react';
 import { Toast } from '.';
 import { Duration, Easing, IconSize } from '../../../constants/Style';

--- a/packages/core/src/components/feedback/ToastLegacy2/index.story.tsx
+++ b/packages/core/src/components/feedback/ToastLegacy2/index.story.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { iconElements, type IconName } from '@learn-react/icon';
-import { css } from '@linaria/core';
 import { useMemo, useReducer, useState, type ChangeEvent } from 'react';
 import { Toast } from '.';
 import { FontSize, LineHeight } from '../../../constants/Style';

--- a/packages/core/src/components/inputs/Button/index.story.tsx
+++ b/packages/core/src/components/inputs/Button/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { Button } from '.';
 import { gutter } from '../../../helpers/Style';
 import { Icon } from '../../dataDisplay/Icon';

--- a/packages/core/src/components/inputs/Button/index.tsx
+++ b/packages/core/src/components/inputs/Button/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@linaria/core';
+import { css, cx } from '@emotion/css';
 import {
   Children,
   forwardRef,

--- a/packages/core/src/components/inputs/Calendar/Item.tsx
+++ b/packages/core/src/components/inputs/Calendar/Item.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { BorderRadius, Duration, FontSize, IconSize } from '../../../constants/Style';
 import { cssVar, square } from '../../../helpers/Style';
 

--- a/packages/core/src/components/inputs/Calendar/index.tsx
+++ b/packages/core/src/components/inputs/Calendar/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import {
   addMonths,
   endOfDay,

--- a/packages/core/src/components/inputs/Checkbox/index.tsx
+++ b/packages/core/src/components/inputs/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useEffect, useRef, type ChangeEvent, type ReactNode } from 'react';
 import { BorderRadius, Duration, FontSize } from '../../../constants/Style';
 import { cssVar, gutter, square } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/ComboBox/index.tsx
+++ b/packages/core/src/components/inputs/ComboBox/index.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { type IconName } from '@learn-react/icon';
-import { css } from '@linaria/core';
 import { useId, useState, type ChangeEvent } from 'react';
 import { Duration, FontSize, IconSize, LineHeight } from '../../../constants/Style';
 import { cssVar, gutter, square } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/FormLabel/index.story.tsx
+++ b/packages/core/src/components/inputs/FormLabel/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useId } from 'react';
 import { FormLabel } from '.';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/FormLabel/index.tsx
+++ b/packages/core/src/components/inputs/FormLabel/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useId, type ReactNode } from 'react';
 import { Icon } from '../../../components/dataDisplay/Icon';
 import { Tooltip } from '../../../components/dataDisplay/Tooltip';

--- a/packages/core/src/components/inputs/IconButton/index.story.tsx
+++ b/packages/core/src/components/inputs/IconButton/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { IconButton } from '.';
 import { gutter } from '../../../helpers/Style';
 

--- a/packages/core/src/components/inputs/IconButton/index.tsx
+++ b/packages/core/src/components/inputs/IconButton/index.tsx
@@ -1,5 +1,5 @@
+import { css, cx } from '@emotion/css';
 import { type IconName } from '@learn-react/icon';
-import { css, cx } from '@linaria/core';
 import {
   forwardRef,
   useMemo,

--- a/packages/core/src/components/inputs/LabeledSlider/index.tsx
+++ b/packages/core/src/components/inputs/LabeledSlider/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { type ChangeEvent } from 'react';
 
 type Props = {

--- a/packages/core/src/components/inputs/Radio/index.tsx
+++ b/packages/core/src/components/inputs/Radio/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { type ChangeEvent, type ReactNode } from 'react';
 import { BorderRadius, Duration, FontSize } from '../../../constants/Style';
 import { cssVar, gutter, square } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/Range/index.tsx
+++ b/packages/core/src/components/inputs/Range/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { type ChangeEvent } from 'react';
 import { BorderRadius, Duration } from '../../../constants/Style';
 import { cssVar, square } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/Select/index.tsx
+++ b/packages/core/src/components/inputs/Select/index.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { type IconName } from '@learn-react/icon';
-import { css } from '@linaria/core';
 import { useMemo, type ChangeEvent } from 'react';
 import { Duration, FontSize, LineHeight } from '../../../constants/Style';
 import { cssVar, gutter, square } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/TextArea/index.story.tsx
+++ b/packages/core/src/components/inputs/TextArea/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useState } from 'react';
 import { TextArea } from '.';
 import { FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/inputs/TextArea/index.tsx
+++ b/packages/core/src/components/inputs/TextArea/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { type ChangeEvent } from 'react';
 import { Duration, FontSize, LineHeight } from '../../../constants/Style';
 import { cssVar, gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/TextField/index.story.tsx
+++ b/packages/core/src/components/inputs/TextField/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useState } from 'react';
 import { TextField } from '.';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/inputs/TextField/index.tsx
+++ b/packages/core/src/components/inputs/TextField/index.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { type IconName } from '@learn-react/icon';
-import { css } from '@linaria/core';
 import { type ChangeEvent } from 'react';
 import { Duration, FontSize, LineHeight } from '../../../constants/Style';
 import { cssVar, gutter, square } from '../../../helpers/Style';

--- a/packages/core/src/components/navigation/Menu/index.story.tsx
+++ b/packages/core/src/components/navigation/Menu/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useState } from 'react';
 import { useDropdownMenu } from '.';
 import { FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/navigation/Sidebar/index.tsx
+++ b/packages/core/src/components/navigation/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@linaria/core';
+import { css, cx } from '@emotion/css';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { BorderRadius, Duration, FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/navigation/Tabs/index.tsx
+++ b/packages/core/src/components/navigation/Tabs/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@linaria/core';
+import { css, cx } from '@emotion/css';
 import { useId, type ChangeEvent } from 'react';
 import { Duration, FontSize, LineHeight } from '../../../constants/Style';
 import { cssVar, gutter, textEllipsis, visuallyHidden } from '../../../helpers/Style';

--- a/packages/core/src/components/surfaces/Card/index.story.tsx
+++ b/packages/core/src/components/surfaces/Card/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { Card } from '.';
 import { FontSize, LineHeight } from '../../../constants/Style';
 import { gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/surfaces/Card/index.tsx
+++ b/packages/core/src/components/surfaces/Card/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@linaria/core';
+import { css, cx } from '@emotion/css';
 import { type CSSProperties, type ReactNode } from 'react';
 import { Duration, Easing } from '../../../constants/Style';
 import { cssVar, gutter } from '../../../helpers/Style';

--- a/packages/core/src/components/surfaces/SplashBanner/index.tsx
+++ b/packages/core/src/components/surfaces/SplashBanner/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { FontSize } from '../../../constants/Style';
 import { gutter } from '../../../helpers/Style';
 

--- a/packages/core/src/components/utils/Box/index.tsx
+++ b/packages/core/src/components/utils/Box/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { type ReactNode } from 'react';
 
 type Props = {

--- a/packages/core/src/components/utils/Modal/index.story.tsx
+++ b/packages/core/src/components/utils/Modal/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useState } from 'react';
 import { Modal } from '.';
 import { FontSize, LineHeight } from '../../../constants/Style';

--- a/packages/core/src/components/utils/Modal/index.tsx
+++ b/packages/core/src/components/utils/Modal/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { Color, Duration, Easing, ZIndex } from '../../../constants/Style';

--- a/packages/core/src/components/utils/Popover/index.story.tsx
+++ b/packages/core/src/components/utils/Popover/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useState, type ComponentProps, type MouseEvent } from 'react';
 import { Popover } from '.';
 import { FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/utils/Popover/index.tsx
+++ b/packages/core/src/components/utils/Popover/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@linaria/core';
+import { css, cx } from '@emotion/css';
 import { useEffect, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { Duration, ZIndex } from '../../../constants/Style';

--- a/packages/core/src/components/utils/SplitPane/Pane.tsx
+++ b/packages/core/src/components/utils/SplitPane/Pane.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { forwardRef, type ComponentProps, type ForwardedRef, type ReactNode } from 'react';
 import { type SplitPane } from '.';
 

--- a/packages/core/src/components/utils/SplitPane/Splitter.tsx
+++ b/packages/core/src/components/utils/SplitPane/Splitter.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { type ComponentProps, type MouseEvent } from 'react';
 import { type SplitPane } from '.';
 import { Duration } from '../../../constants/Style';

--- a/packages/core/src/components/utils/SplitPane/index.tsx
+++ b/packages/core/src/components/utils/SplitPane/index.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@linaria/core';
+import { css, cx } from '@emotion/css';
 import { Children, useRef, useState, type MouseEvent, type ReactNode } from 'react';
 import { Pane } from './Pane';
 import { Splitter } from './Splitter';

--- a/packages/core/src/components/utils/Transition/index.story.tsx
+++ b/packages/core/src/components/utils/Transition/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useState } from 'react';
 import { Transition } from '.';
 import { FontSize } from '../../../constants/Style';

--- a/packages/core/src/components/utils/Transition/index.tsx
+++ b/packages/core/src/components/utils/Transition/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useMemo, useRef, useState, type ReactNode } from 'react';
 import { Duration, Easing } from '../../../constants/Style';
 

--- a/packages/core/src/constants/Style/index.story.tsx
+++ b/packages/core/src/constants/Style/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { Color, FontSize, LineHeight } from '.';
 import { cssVar, gutter, textEllipsis } from '../../helpers/Style';
 

--- a/packages/core/src/helpers/Style.ts
+++ b/packages/core/src/helpers/Style.ts
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css, injectGlobal } from '@emotion/css';
 import { color } from 'csx';
 import { Color, FontFamily, Shadow } from '../constants/Style';
 import NotoSansMedium from './fonts/noto-sans/NotoSansJP-Medium.woff';
@@ -90,156 +90,152 @@ export function textEllipsis() {
  * @see https://github.com/hankchizljaw/modern-css-reset/blob/master/dist/reset.min.css
  */
 export function applyResetStyle() {
-  return css`
-    :global() {
-      *,
-      *::before,
-      *::after {
-        box-sizing: border-box;
-        margin: 0;
-      }
+  return injectGlobal`
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+      margin: 0;
+    }
 
-      html {
-        overflow-x: hidden;
-        font-family: sans-serif;
-        -webkit-text-size-adjust: 100%;
-        -webkit-tap-highlight-color: rgb(0 0 0 / 0%);
-        scroll-behavior: smooth;
-      }
+    html {
+      overflow-x: hidden;
+      font-family: sans-serif;
+      -webkit-text-size-adjust: 100%;
+      -webkit-tap-highlight-color: rgb(0 0 0 / 0%);
+      scroll-behavior: smooth;
+    }
 
-      body {
-        min-height: 100dvh;
-        text-rendering: optimizespeed;
-        line-height: 1.5;
-      }
+    body {
+      min-height: 100dvh;
+      text-rendering: optimizespeed;
+      line-height: 1.5;
+    }
 
-      a:not([class]) {
-        text-decoration-skip-ink: auto;
-      }
+    a:not([class]) {
+      text-decoration-skip-ink: auto;
+    }
 
-      img,
-      picture {
-        display: block;
-        max-width: 100%;
-      }
+    img,
+    picture {
+      display: block;
+      max-width: 100%;
+    }
 
-      input,
-      button,
-      textarea,
-      select {
-        font: inherit;
+    input,
+    button,
+    textarea,
+    select {
+      font: inherit;
 
-        &:focus:not(:focus-visible) {
-          /* キーボード操作"以外"でフォーカスされた際は outline を消す */
-          outline: 0;
-        }
+      &:focus:not(:focus-visible) {
+        /* キーボード操作"以外"でフォーカスされた際は outline を消す */
+        outline: 0;
       }
+    }
 
-      main {
-        display: block;
-        overflow-x: hidden;
-      }
+    main {
+      display: block;
+      overflow-x: hidden;
     }
   `;
 }
 
 export function applyGlobalStyle() {
-  return css`
-    :global() {
-      @font-face {
-        font-family: 'Noto Sans Japanese';
-        font-style: normal;
-        font-weight: normal;
-        src: local('Noto Sans Japanese'), url(${NotoSansRegular}) format('woff');
-        font-display: swap;
-      }
+  return injectGlobal`
+    @font-face {
+      font-family: 'Noto Sans Japanese';
+      font-style: normal;
+      font-weight: normal;
+      src: local('Noto Sans Japanese'), url(${NotoSansRegular}) format('woff');
+      font-display: swap;
+    }
 
-      @font-face {
-        font-family: 'Noto Sans Japanese';
-        font-style: normal;
-        font-weight: bold;
-        src: local('Noto Sans Japanese Bold'), url(${NotoSansMedium}) format('woff');
-        font-display: swap;
-      }
+    @font-face {
+      font-family: 'Noto Sans Japanese';
+      font-style: normal;
+      font-weight: bold;
+      src: local('Noto Sans Japanese Bold'), url(${NotoSansMedium}) format('woff');
+      font-display: swap;
+    }
 
-      @font-face {
-        font-family: 'Noto Serif Japanese';
-        font-style: normal;
-        font-weight: normal;
-        src: local('Noto Serif Japanese'), url(${NotoSerifRegular}) format('woff');
-        font-display: swap;
-      }
+    @font-face {
+      font-family: 'Noto Serif Japanese';
+      font-style: normal;
+      font-weight: normal;
+      src: local('Noto Serif Japanese'), url(${NotoSerifRegular}) format('woff');
+      font-display: swap;
+    }
 
-      @font-face {
-        font-family: 'Noto Serif Japanese';
-        font-style: normal;
-        font-weight: bold;
-        src: local('Noto Serif Japanese Bold'), url(${NotoSerifSemiBold}) format('woff');
-        font-display: swap;
-      }
+    @font-face {
+      font-family: 'Noto Serif Japanese';
+      font-style: normal;
+      font-weight: bold;
+      src: local('Noto Serif Japanese Bold'), url(${NotoSerifSemiBold}) format('woff');
+      font-display: swap;
+    }
 
+    :root {
+      ${Object.entries({ ...Color, ...Shadow }).reduce(
+        (acc, [key, value]) => ({
+          ...acc,
+          [`--${key}`]: value.light,
+        }),
+        {},
+      )}
+    }
+
+    @media (prefers-color-scheme: dark) {
       :root {
+        color-scheme: dark;
+
         ${Object.entries({ ...Color, ...Shadow }).reduce(
           (acc, [key, value]) => ({
             ...acc,
-            [`--${key}`]: value.light,
+            [`--${key}`]: value.dark,
           }),
           {},
         )}
       }
+    }
 
-      @media (prefers-color-scheme: dark) {
-        :root {
-          color-scheme: dark;
+    html,
+    body {
+      padding: 0;
+      margin: 0;
+      font-family: ${FontFamily.Default};
+      font-weight: 500;
+      font-feature-settings: palt 1;
+      background-color: ${cssVar('TextureBody')};
+    }
 
-          ${Object.entries({ ...Color, ...Shadow }).reduce(
-            (acc, [key, value]) => ({
-              ...acc,
-              [`--${key}`]: value.dark,
-            }),
-            {},
-          )}
-        }
-      }
+    body,
+    h1,
+    h2,
+    h3,
+    h4,
+    p,
+    ul,
+    ol,
+    figure,
+    blockquote,
+    dl,
+    dd {
+      margin: 0;
+    }
 
-      html,
-      body {
-        padding: 0;
-        margin: 0;
-        font-family: ${FontFamily.Default};
-        font-weight: 500;
-        font-feature-settings: palt 1;
-        background-color: ${cssVar('TextureBody')};
-      }
+    ul,
+    ol {
+      padding: 0;
+      list-style: none;
+    }
+    /* stylelint-disable-next-line no-descending-specificity */
+    a {
+      color: inherit;
+      text-decoration: none;
 
-      body,
-      h1,
-      h2,
-      h3,
-      h4,
-      p,
-      ul,
-      ol,
-      figure,
-      blockquote,
-      dl,
-      dd {
-        margin: 0;
-      }
-
-      ul,
-      ol {
-        padding: 0;
-        list-style: none;
-      }
-      /* stylelint-disable-next-line no-descending-specificity */
-      a {
-        color: inherit;
-        text-decoration: none;
-
-        &:hover {
-          text-decoration: underline;
-        }
+      &:hover {
+        text-decoration: underline;
       }
     }
   `;

--- a/packages/core/src/hooks/useData/index.story.tsx
+++ b/packages/core/src/hooks/useData/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { Suspense, useState, useTransition, type ChangeEvent } from 'react';
 import { useData } from '.';
 import { ErrorBoundary, type FallbackProps } from '../../components/utils/ErrorBoundary';

--- a/packages/core/src/hooks/useHotkeys/index.story.tsx
+++ b/packages/core/src/hooks/useHotkeys/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useState } from 'react';
 import { useHotkeys } from '.';
 import { Modal } from '../../components/utils/Modal';

--- a/packages/core/src/hooks/useListBox/WithButton.story.tsx
+++ b/packages/core/src/hooks/useListBox/WithButton.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useState } from 'react';
 import { useListBox } from '.';
 import { Icon } from '../../components/dataDisplay/Icon';

--- a/packages/core/src/hooks/useListBox/WithIconButton.story.tsx
+++ b/packages/core/src/hooks/useListBox/WithIconButton.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useState } from 'react';
 import { useListBox } from '.';
 import { IconButton } from '../../components/inputs/IconButton';

--- a/packages/core/src/hooks/useListBox/WithPopover.story.tsx
+++ b/packages/core/src/hooks/useListBox/WithPopover.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useId, useState } from 'react';
 import { useListBox } from '.';
 import { Popover } from '../../components/utils/Popover';

--- a/packages/core/src/hooks/useScrollTo/index.story.tsx
+++ b/packages/core/src/hooks/useScrollTo/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useRef, useState, type ChangeEvent, type MouseEvent } from 'react';
 import { useScrollTo } from '.';
 import { cssVar, gutter, textEllipsis } from '../../helpers/Style';

--- a/packages/core/src/hooks/useShuffleLetters/index.story.tsx
+++ b/packages/core/src/hooks/useShuffleLetters/index.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useRef, useState, type ReactNode } from 'react';
 import { useShuffleLetters } from '.';
 import { gutter } from '../../helpers/Style';

--- a/packages/core/src/hooks/useSpy/Basic.story.tsx
+++ b/packages/core/src/hooks/useSpy/Basic.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useRef, useState, type ChangeEvent } from 'react';
 import { useSpy } from '.';
 import { cssVar, gutter, textEllipsis } from '../../helpers/Style';

--- a/packages/core/src/hooks/useSpy/WithUseScroll.story.tsx
+++ b/packages/core/src/hooks/useSpy/WithUseScroll.story.tsx
@@ -1,4 +1,4 @@
-import { css } from '@linaria/core';
+import { css } from '@emotion/css';
 import { useRef, useState, type ChangeEvent, type MouseEvent } from 'react';
 import { useSpy } from '.';
 import { cssVar, gutter, textEllipsis } from '../../helpers/Style';

--- a/packages/routing/src/01-basic/components/Navigation.tsx
+++ b/packages/routing/src/01-basic/components/Navigation.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Link } from 'react-router-dom';
 import { Router } from '../constants/Router';
 

--- a/packages/routing/src/01-basic/index.tsx
+++ b/packages/routing/src/01-basic/index.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { BrowserRouter, generatePath, Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import { Navigation } from './components/Navigation';
 import { Router } from './constants/Router';

--- a/packages/routing/src/01-basic/pages/Friends/Friend.tsx
+++ b/packages/routing/src/01-basic/pages/Friends/Friend.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useParams } from 'react-router-dom';
 import { getFriendById } from '../Friends';
 

--- a/packages/routing/src/01-basic/pages/Friends/index.tsx
+++ b/packages/routing/src/01-basic/pages/Friends/index.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { generatePath, Link, Outlet } from 'react-router-dom';
 import { Router } from '../../constants/Router';
 

--- a/packages/routing/src/02-nest-routes-deep/components/Navigation.tsx
+++ b/packages/routing/src/02-nest-routes-deep/components/Navigation.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Link } from 'react-router-dom';
 import { Router } from '../constants/Router';
 

--- a/packages/routing/src/02-nest-routes-deep/index.tsx
+++ b/packages/routing/src/02-nest-routes-deep/index.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { type ReactNode } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Navigation } from './components/Navigation';

--- a/packages/routing/src/02-nest-routes-deep/pages/Friends/Friend.tsx
+++ b/packages/routing/src/02-nest-routes-deep/pages/Friends/Friend.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useParams } from 'react-router-dom';
 import { getFriendById } from '.';
 

--- a/packages/routing/src/02-nest-routes-deep/pages/Friends/index.tsx
+++ b/packages/routing/src/02-nest-routes-deep/pages/Friends/index.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { generatePath, Navigate, NavLink, Route, Routes } from 'react-router-dom';
 import { Router } from '../../constants/Router';
 import { Friend } from './Friend';

--- a/packages/routing/src/03-route-objects/components/Navigation.tsx
+++ b/packages/routing/src/03-route-objects/components/Navigation.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Link } from 'react-router-dom';
 
 export const Navigation = () => (

--- a/packages/routing/src/03-route-objects/index.tsx
+++ b/packages/routing/src/03-route-objects/index.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { BrowserRouter, Outlet, useRoutes, type RouteObject } from 'react-router-dom';
 import { Navigation } from './components/Navigation';
 import { About } from './pages/About';

--- a/packages/routing/src/03-route-objects/pages/Friends/Friend.tsx
+++ b/packages/routing/src/03-route-objects/pages/Friends/Friend.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useParams } from 'react-router-dom';
 import { getFriendById } from '.';
 

--- a/packages/routing/src/03-route-objects/pages/Friends/index.tsx
+++ b/packages/routing/src/03-route-objects/pages/Friends/index.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Link, Navigate, useRoutes, type RouteObject } from 'react-router-dom';
 import { Friend } from './Friend';
 

--- a/packages/routing/src/04-with-page-transition/components/Navigation.tsx
+++ b/packages/routing/src/04-with-page-transition/components/Navigation.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Link } from 'react-router-dom';
 import { Router } from '../constants/Router';
 

--- a/packages/routing/src/04-with-page-transition/index.tsx
+++ b/packages/routing/src/04-with-page-transition/index.tsx
@@ -1,7 +1,7 @@
+import { css } from '@emotion/css';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { withSuspense } from '@learn-react/core/helpers/Component';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { lazy, type ReactNode } from 'react';
 import { BrowserRouter, Route } from 'react-router-dom';
 import { Navigation } from './components/Navigation';

--- a/packages/routing/src/04-with-page-transition/pages/Stones/Member.tsx
+++ b/packages/routing/src/04-with-page-transition/pages/Stones/Member.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useParams } from 'react-router-dom';
 import { getMemberById } from '.';
 

--- a/packages/routing/src/04-with-page-transition/pages/Stones/index.tsx
+++ b/packages/routing/src/04-with-page-transition/pages/Stones/index.tsx
@@ -1,7 +1,7 @@
+import { css } from '@emotion/css';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { withSuspense } from '@learn-react/core/helpers/Component';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { lazy } from 'react';
 import { generatePath, Navigate, NavLink, Route } from 'react-router-dom';
 import { Router } from '../../constants/Router';

--- a/packages/routing/src/index.tsx
+++ b/packages/routing/src/index.tsx
@@ -1,8 +1,8 @@
+import { css } from '@emotion/css';
 import { LineHeight } from '@learn-react/core/constants/Style';
 import { createContainer } from '@learn-react/core/helpers/Container';
 import { StorageProxy } from '@learn-react/core/helpers/Storage';
 import { applyGlobalStyle, applyResetStyle, gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { StrictMode, useEffect, useState, type ChangeEvent, type FC } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Basic } from './01-basic';

--- a/packages/statement/src/21-mobx-basic/bootstraps/App.tsx
+++ b/packages/statement/src/21-mobx-basic/bootstraps/App.tsx
@@ -1,7 +1,7 @@
+import { css } from '@emotion/css';
 import { Sidebar } from '@learn-react/core/components/navigation/Sidebar';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { type ComponentProps } from 'react';
 import { Route } from 'react-router-dom';
 import { Router } from '../../@core/constants/Router';

--- a/packages/statement/src/21-mobx-basic/pages/ListPage.tsx
+++ b/packages/statement/src/21-mobx-basic/pages/ListPage.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { observer } from 'mobx-react';
 import { createContext, useMemo, useState, type ChangeEvent } from 'react';
 import { ListStore } from '../stores/ListStore';

--- a/packages/statement/src/22-mobx-hooks/bootstraps/App.tsx
+++ b/packages/statement/src/22-mobx-hooks/bootstraps/App.tsx
@@ -1,6 +1,6 @@
+import { css } from '@emotion/css';
 import { Sidebar } from '@learn-react/core/components/navigation/Sidebar';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
-import { css } from '@linaria/core';
 import { type ComponentProps } from 'react';
 import { Route } from 'react-router-dom';
 import { Router } from '../../@core/constants/Router';

--- a/packages/statement/src/22-mobx-hooks/pages/ListPage.tsx
+++ b/packages/statement/src/22-mobx-hooks/pages/ListPage.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { toJS } from 'mobx';
 import { observer } from 'mobx-react';
 import { useState, type ChangeEvent } from 'react';

--- a/packages/statement/src/22-mobx-hooks/pages/Users/components/Log.tsx
+++ b/packages/statement/src/22-mobx-hooks/pages/Users/components/Log.tsx
@@ -1,6 +1,6 @@
+import { css } from '@emotion/css';
 import { LineHeight } from '@learn-react/core/constants/Style';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { observer } from 'mobx-react';
 import { UsersStore } from '../stores/UsersStore';
 

--- a/packages/statement/src/22-mobx-hooks/pages/Users/index.tsx
+++ b/packages/statement/src/22-mobx-hooks/pages/Users/index.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useState } from 'react';
 import { GetByParamForm } from './components/GetByParamForm';
 import { GetForm } from './components/GetForm';

--- a/packages/statement/src/31-unstated-basic/bootstraps/App.tsx
+++ b/packages/statement/src/31-unstated-basic/bootstraps/App.tsx
@@ -1,7 +1,7 @@
+import { css } from '@emotion/css';
 import { Sidebar } from '@learn-react/core/components/navigation/Sidebar';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { type ComponentProps } from 'react';
 import { Route } from 'react-router-dom';
 import { Router } from '../../@core/constants/Router';

--- a/packages/statement/src/31-unstated-basic/pages/ListPage.tsx
+++ b/packages/statement/src/31-unstated-basic/pages/ListPage.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useState, type ChangeEvent } from 'react';
 import { ListContainer } from '../containers/ListContainer';
 

--- a/packages/statement/src/31-unstated-basic/pages/profiles/index.tsx
+++ b/packages/statement/src/31-unstated-basic/pages/profiles/index.tsx
@@ -1,6 +1,6 @@
+import { css } from '@emotion/css';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Navigate, Route } from 'react-router-dom';
 import { Router } from '../../../@core/constants/Router';
 import { ProfileContainer } from '../../containers/ProfileContainer';

--- a/packages/statement/src/41-constate-basic/bootstraps/App.tsx
+++ b/packages/statement/src/41-constate-basic/bootstraps/App.tsx
@@ -1,7 +1,7 @@
+import { css } from '@emotion/css';
 import { Sidebar } from '@learn-react/core/components/navigation/Sidebar';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { type ComponentProps } from 'react';
 import { Route } from 'react-router-dom';
 import { Router } from '../../@core/constants/Router';

--- a/packages/statement/src/41-constate-basic/pages/ListPage.tsx
+++ b/packages/statement/src/41-constate-basic/pages/ListPage.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useState, type ChangeEvent } from 'react';
 import { ListProvider, useAddListItem, useEditListItem, useListItems } from '../containers/ListContainer';
 

--- a/packages/statement/src/41-constate-basic/pages/profiles/index.tsx
+++ b/packages/statement/src/41-constate-basic/pages/profiles/index.tsx
@@ -1,6 +1,6 @@
+import { css } from '@emotion/css';
 import { PageTransition } from '@learn-react/core/components/utils/PageTransition';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Navigate, Route } from 'react-router-dom';
 import { Router } from '../../../@core/constants/Router';
 import { ProfileContainer } from '../../containers/ProfileContainer';

--- a/packages/statement/src/App.tsx
+++ b/packages/statement/src/App.tsx
@@ -1,6 +1,6 @@
+import { css } from '@emotion/css';
 import { StorageProxy } from '@learn-react/core/helpers/Storage';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useEffect, useState, type ChangeEvent, type FC } from 'react';
 import { MobxHooksApp } from './22-mobx-hooks';
 import { UnstatedBasicApp } from './31-unstated-basic';

--- a/packages/try/src/Bubbling/index.story.tsx
+++ b/packages/try/src/Bubbling/index.story.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { type MouseEvent } from 'react';
 
 export const Story = () => {

--- a/packages/try/src/Suspense2/index.story.tsx
+++ b/packages/try/src/Suspense2/index.story.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { useState, type ChangeEvent } from 'react';
 import { DataFetching1 } from './DataFetching1';
 import { DataFetching2 } from './DataFetching2';

--- a/packages/try/src/Transition2/1_Prepare.story.tsx
+++ b/packages/try/src/Transition2/1_Prepare.story.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Issues } from './common/Issues';
 import { usePageNumberV1 } from './common/usePageNumber';
 

--- a/packages/try/src/Transition2/2_WithSuspense.story.tsx
+++ b/packages/try/src/Transition2/2_WithSuspense.story.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Suspense } from 'react';
 import { Issues } from './common/Issues';
 import { usePageNumberV1 } from './common/usePageNumber';

--- a/packages/try/src/Transition2/3_WithTransition.story.tsx
+++ b/packages/try/src/Transition2/3_WithTransition.story.tsx
@@ -1,5 +1,5 @@
+import { css } from '@emotion/css';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Suspense } from 'react';
 import { Issues } from './common/Issues';
 import { usePageNumberV2 } from './common/usePageNumber';

--- a/packages/try/src/Transition2/4_WithLoadable.story.tsx
+++ b/packages/try/src/Transition2/4_WithLoadable.story.tsx
@@ -1,6 +1,6 @@
+import { css } from '@emotion/css';
 import { FontSize } from '@learn-react/core/constants/Style';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import { Suspense } from 'react';
 import { fetchIssues, useData, type IssueType } from './common/Api';
 import { usePageNumberV2 } from './common/usePageNumber';

--- a/packages/try/src/Transition2/common/Issues.tsx
+++ b/packages/try/src/Transition2/common/Issues.tsx
@@ -1,6 +1,6 @@
+import { css } from '@emotion/css';
 import { FontSize } from '@learn-react/core/constants/Style';
 import { cssVar, gutter } from '@learn-react/core/helpers/Style';
-import { css } from '@linaria/core';
 import useSWR from 'swr';
 
 type IssueType = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,8 @@ importers:
 
   .:
     specifiers:
-      '@babel/preset-typescript': 7.21.0
       '@commitlint/cli': 17.4.4
-      '@linaria/core': 3.0.0-beta.22
-      '@linaria/rollup': 3.0.0-beta.23
-      '@linaria/shaker': 3.0.0-beta.23
-      '@linaria/stylelint': 3.0.0-beta.23
+      '@emotion/css': 11.10.6
       '@stylelint/postcss-css-in-js': 0.38.0
       '@types/jest': 29.4.0
       '@types/node': 18.14.6
@@ -19,8 +15,6 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.54.1
       '@typescript-eslint/parser': 5.54.1
       '@vitejs/plugin-react': 3.1.0
-      babel-loader: 9.1.2
-      babel-plugin-module-resolver: 5.0.0
       cheerio: 1.0.0-rc.12
       chokidar: 3.5.3
       constate: 3.3.2
@@ -46,6 +40,7 @@ importers:
       mobx-react: 7.6.0
       npm-run-all: 4.1.5
       pdfjs-dist: 3.4.120
+      postcss: 8.4.21
       postcss-syntax: 0.36.2
       prettier: 2.8.4
       prettier-plugin-organize-imports: 3.2.2
@@ -68,7 +63,7 @@ importers:
       vite: 4.1.4
       yargs: 17.7.1
     dependencies:
-      '@linaria/core': 3.0.0-beta.22
+      '@emotion/css': 11.10.6
       constate: 3.3.2_react@18.2.0
       csx: 10.0.2
       date-fns: 2.29.3
@@ -83,12 +78,8 @@ importers:
       react-router-dom: 6.8.2_biqbaboplfbrettd7655fr4n2y
       swr: 2.1.0_react@18.2.0
     devDependencies:
-      '@babel/preset-typescript': 7.21.0
       '@commitlint/cli': 17.4.4
-      '@linaria/rollup': 3.0.0-beta.23
-      '@linaria/shaker': 3.0.0-beta.23
-      '@linaria/stylelint': 3.0.0-beta.23
-      '@stylelint/postcss-css-in-js': 0.38.0_postcss-syntax@0.36.2
+      '@stylelint/postcss-css-in-js': 0.38.0_64375vj2stjdn6gyt55zwvoboa
       '@types/jest': 29.4.0
       '@types/node': 18.14.6
       '@types/qs': 6.9.7
@@ -97,8 +88,6 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.54.1_mlk7dnz565t663n4razh6a6v6i
       '@typescript-eslint/parser': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
       '@vitejs/plugin-react': 3.1.0_vite@4.1.4
-      babel-loader: 9.1.2
-      babel-plugin-module-resolver: 5.0.0
       cheerio: 1.0.0-rc.12
       chokidar: 3.5.3
       cspell: 6.28.0
@@ -116,7 +105,8 @@ importers:
       jest-environment-jsdom: 29.5.0
       lint-staged: 13.1.4
       npm-run-all: 4.1.5
-      postcss-syntax: 0.36.2
+      postcss: 8.4.21
+      postcss-syntax: 0.36.2_postcss@8.4.21
       prettier: 2.8.4
       prettier-plugin-organize-imports: 3.2.2_silln3pw57har7jydmecgzoypa
       stylelint: 15.2.0
@@ -172,7 +162,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.18.6
-    dev: true
 
   /@babel/compat-data/7.20.10:
     resolution: {integrity: sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==}
@@ -211,21 +200,6 @@ packages:
       jsesc: 2.5.2
     dev: true
 
-  /@babel/helper-annotate-as-pure/7.18.6:
-    resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.2
-    dev: true
-
-  /@babel/helper-builder-binary-assignment-operator-visitor/7.18.9:
-    resolution: {integrity: sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.21.2
-    dev: true
-
   /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.12:
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
     engines: {node: '>=6.9.0'}
@@ -240,80 +214,9 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /@babel/helper-create-class-features-plugin/7.21.0:
-    resolution: {integrity: sha512-Q8wNiMIdwsv5la5SPxNYzzkPnjgC0Sy0i7jLkVOCdllu/xcVNkr3TeZzbHBJrj+XXRqzX5uCyCoV9eu6xUG7KQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/helper-create-class-features-plugin/7.21.0_@babel+core@7.20.12:
-    resolution: {integrity: sha512-Q8wNiMIdwsv5la5SPxNYzzkPnjgC0Sy0i7jLkVOCdllu/xcVNkr3TeZzbHBJrj+XXRqzX5uCyCoV9eu6xUG7KQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/helper-create-regexp-features-plugin/7.19.0_@babel+core@7.20.12:
-    resolution: {integrity: sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-annotate-as-pure': 7.18.6
-      regexpu-core: 5.2.2
-    dev: true
-
-  /@babel/helper-define-polyfill-provider/0.3.3_@babel+core@7.20.12:
-    resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
-    peerDependencies:
-      '@babel/core': ^7.4.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      debug: 4.3.4
-      lodash.debounce: 4.0.8
-      resolve: 1.22.1
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/helper-environment-visitor/7.18.9:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-explode-assignable-expression/7.18.6:
-    resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.2
     dev: true
 
   /@babel/helper-function-name/7.21.0:
@@ -331,19 +234,11 @@ packages:
       '@babel/types': 7.21.2
     dev: true
 
-  /@babel/helper-member-expression-to-functions/7.21.0:
-    resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.2
-    dev: true
-
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.2
-    dev: true
 
   /@babel/helper-module-transforms/7.20.11:
     resolution: {integrity: sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==}
@@ -361,56 +256,13 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-optimise-call-expression/7.18.6:
-    resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.2
-    dev: true
-
   /@babel/helper-plugin-utils/7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-remap-async-to-generator/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.21.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/helper-replace-supers/7.20.7:
-    resolution: {integrity: sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
-      '@babel/types': 7.21.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/helper-simple-access/7.20.2:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.2
-    dev: true
-
-  /@babel/helper-skip-transparent-expression-wrappers/7.20.0:
-    resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.2
@@ -426,28 +278,14 @@ packages:
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-identifier/7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option/7.21.0:
     resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-wrap-function/7.19.0:
-    resolution: {integrity: sha512-txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-function-name': 7.21.0
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
-      '@babel/types': 7.21.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/helpers/7.20.7:
@@ -468,7 +306,6 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
       js-tokens: 4.0.0
-    dev: true
 
   /@babel/parser/7.20.7:
     resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
@@ -476,212 +313,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.21.2
-    dev: true
-
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-AHrP9jadvH7qlOj6PINbgSuphjQUAK7AOT7DPjBo9EHoLhQTnnK5u45e1Hd4DbSQEO9nqPWtQ89r+XEOWFScKg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.13.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-async-generator-functions/7.20.1_@babel+core@7.20.12:
-    resolution: {integrity: sha512-Gh5rchzSwE4kC+o/6T8waD0WHEQIsDmjltY8WnWRXHUdH8axZhuH86Ov9M72YhJfDrZseQwuuWaaIT/TmePp3g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.20.12
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-class-static-block/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-+I3oIiNxrCpup3Gi8n5IGMwj0gOCAjcJUSQEcotNnCCPMEnixawOQ+KeJPlgfjzx+FKQ1QSyZOWe7wmoJp7vhw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.12.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.20.12
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-dynamic-import/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-export-namespace-from/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-logical-assignment-operators/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-128YbMpjCrP35IOExw2Fq+x55LMP42DzhOhX2aNNIdI9avSWl2PI0yuBWarr3RYpZBSPtabfadkH2yeRiMD61Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-object-rest-spread/7.20.2_@babel+core@7.20.12:
-    resolution: {integrity: sha512-Ks6uej9WFK+fvIMesSqbAto5dD8Dz4VuuFvGJFKgIGSkJuRGcrwGECPA1fDgQK3/DbExBJpEkTeYeB8geIFCSQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.20.10
-      '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-transform-parameters': 7.20.3_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-optional-catch-binding/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-optional-chaining/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-private-property-in-object/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-9Rysx7FOctvT5ouj5JODjAFAkgGoudQuLPamZb0v1TGLpapdNaftzifU8NTWQm0IRjqoYypdrSmyWgkocDQ8Dw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.20.12
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-unicode-property-regex/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.20.12:
@@ -704,44 +335,6 @@ packages:
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.20.12:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.20.12:
-    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.20.12:
-    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.20.12:
-    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-syntax-import-assertions/7.20.0_@babel+core@7.20.12:
-    resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
-    engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -831,16 +424,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.20.12:
-    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.20.12:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
@@ -851,284 +434,8 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-typescript/7.20.0:
-    resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-arrow-functions/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-async-to-generator/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-ARE5wZLKnTgPW7/1ftQmSi1CmkqqHo2DNmtztFhvgtOWSDfq0Cq9/9L+KnZNYSNrydBekhW3rwShduf59RoXag==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.20.12
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-block-scoped-functions/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-block-scoping/7.20.2_@babel+core@7.20.12:
-    resolution: {integrity: sha512-y5V15+04ry69OV2wULmwhEA6jwSWXO1TwAtIwiPXcvHcoOQUqpyMVd2bDsQJMW8AurjulIyUV8kDqtjSwHy1uQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-classes/7.20.2_@babel+core@7.20.12:
-    resolution: {integrity: sha512-9rbPp0lCVVoagvtEyQKSo5L8oo0nQS/iif+lwlAz29MccX2642vWDlSZK+2T2buxbopotId2ld7zZAzRfz9j1g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-computed-properties/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-destructuring/7.20.2_@babel+core@7.20.12:
-    resolution: {integrity: sha512-mENM+ZHrvEgxLTBXUiQ621rRXZes3KWUv6NdQlrnr1TkWVw+hUjQBZuP2X32qKlrlG2BzgR95gkuCRSkJl8vIw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-dotall-regex/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-duplicate-keys/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-exponentiation-operator/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-for-of/7.18.8_@babel+core@7.20.12:
-    resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-function-name/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-literals/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-member-expression-literals/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-modules-amd/7.19.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-uG3od2mXvAtIFQIh0xrpLH6r5fpSQN04gIVovl+ODLdUMANokxQLZnPBHcjmv3GxRjnqwLuHvppjjcelqUFZvg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-commonjs/7.19.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-simple-access': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-systemjs/7.19.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-fqGLBepcc3kErfR9R3DnVpURmckXP7gj7bAlrTQyBxrigFqszZCkFkcoxzCp2v32XmwXLvbw+8Yq9/b+QqksjQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-identifier': 7.19.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-umd/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-named-capturing-groups-regex/7.19.1_@babel+core@7.20.12:
-    resolution: {integrity: sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-new-target/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-parameters/7.20.3_@babel+core@7.20.12:
-    resolution: {integrity: sha512-oZg/Fpx0YDrj13KsLyO8I/CX3Zdw7z0O9qOd95SqcoIzuqy/WTGWvePeHAnZCN54SfdyjHcb1S30gc8zlzlHcA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-property-literals/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1157,247 +464,11 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-regenerator/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-poqRI2+qiSdeldcz4wTSTXBRryoq3Gc70ye7m7UD5Ww0nE29IXqMl6r7Nd15WBgRd74vloEMlShtH6CKxVzfmQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      regenerator-transform: 0.15.1
-    dev: true
-
-  /@babel/plugin-transform-reserved-words/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-runtime/7.19.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-PRH37lz4JU156lYFW1p8OxE5i7d6Sl/zV58ooyr+q1J1lnQPyg5tIiXlIwNVhJaY4W3TmOtdc8jqdXQcB1v5Yw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.20.12
-      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.20.12
-      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.20.12
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-shorthand-properties/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-spread/7.19.0_@babel+core@7.20.12:
-    resolution: {integrity: sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-    dev: true
-
-  /@babel/plugin-transform-sticky-regex/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-template-literals/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-typeof-symbol/7.18.9_@babel+core@7.20.12:
-    resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-typescript/7.21.0:
-    resolution: {integrity: sha512-xo///XTPp3mDzTtrqXoBlK9eiAYW3wv9JXglcn/u1bi60RW11dEUxIgA8cbnDhutS1zacjMRmAwxE0gMklLnZg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.21.0
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-typescript': 7.20.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-unicode-escapes/7.18.10_@babel+core@7.20.12:
-    resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-unicode-regex/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/preset-env/7.20.2_@babel+core@7.20.12:
-    resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.20.10
-      '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-proposal-async-generator-functions': 7.20.1_@babel+core@7.20.12
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-class-static-block': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-object-rest-spread': 7.20.2_@babel+core@7.20.12
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-private-property-in-object': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.20.12
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.20.12
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.20.12
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-import-assertions': 7.20.0_@babel+core@7.20.12
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.20.12
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.20.12
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.20.12
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.20.12
-      '@babel/plugin-transform-arrow-functions': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-async-to-generator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-block-scoping': 7.20.2_@babel+core@7.20.12
-      '@babel/plugin-transform-classes': 7.20.2_@babel+core@7.20.12
-      '@babel/plugin-transform-computed-properties': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-destructuring': 7.20.2_@babel+core@7.20.12
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.20.12
-      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-amd': 7.19.6_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-commonjs': 7.19.6_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-systemjs': 7.19.6_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.19.1_@babel+core@7.20.12
-      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-parameters': 7.20.3_@babel+core@7.20.12
-      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-regenerator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-spread': 7.19.0_@babel+core@7.20.12
-      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.20.12
-      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/preset-modules': 0.1.5_@babel+core@7.20.12
-      '@babel/types': 7.21.2
-      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.20.12
-      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.20.12
-      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.20.12
-      core-js-compat: 3.26.1
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/preset-modules/0.1.5_@babel+core@7.20.12:
-    resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/types': 7.21.2
-      esutils: 2.0.3
-    dev: true
-
-  /@babel/preset-typescript/7.21.0:
-    resolution: {integrity: sha512-myc9mpoVA5m1rF8K8DgLEatOYFDpwC+RkMkjZ0Du6uI62YvDe8uxIEYVs/VCdSJ097nlALiU/yBC7//3nI+hNg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-transform-typescript': 7.21.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/runtime/7.20.7:
     resolution: {integrity: sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
-    dev: true
 
   /@babel/template/7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
@@ -1433,7 +504,6 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
-    dev: true
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -1905,6 +975,76 @@ packages:
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
     dev: true
+
+  /@emotion/babel-plugin/11.10.6:
+    resolution: {integrity: sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==}
+    dependencies:
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/runtime': 7.20.7
+      '@emotion/hash': 0.9.0
+      '@emotion/memoize': 0.8.0
+      '@emotion/serialize': 1.1.1
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.1.3
+    dev: false
+
+  /@emotion/cache/11.10.5:
+    resolution: {integrity: sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==}
+    dependencies:
+      '@emotion/memoize': 0.8.0
+      '@emotion/sheet': 1.2.1
+      '@emotion/utils': 1.2.0
+      '@emotion/weak-memoize': 0.3.0
+      stylis: 4.1.3
+    dev: false
+
+  /@emotion/css/11.10.6:
+    resolution: {integrity: sha512-88Sr+3heKAKpj9PCqq5A1hAmAkoSIvwEq1O2TwDij7fUtsJpdkV4jMTISSTouFeRvsGvXIpuSuDQ4C1YdfNGXw==}
+    dependencies:
+      '@emotion/babel-plugin': 11.10.6
+      '@emotion/cache': 11.10.5
+      '@emotion/serialize': 1.1.1
+      '@emotion/sheet': 1.2.1
+      '@emotion/utils': 1.2.0
+    dev: false
+
+  /@emotion/hash/0.9.0:
+    resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
+    dev: false
+
+  /@emotion/memoize/0.8.0:
+    resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
+    dev: false
+
+  /@emotion/serialize/1.1.1:
+    resolution: {integrity: sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==}
+    dependencies:
+      '@emotion/hash': 0.9.0
+      '@emotion/memoize': 0.8.0
+      '@emotion/unitless': 0.8.0
+      '@emotion/utils': 1.2.0
+      csstype: 3.1.1
+    dev: false
+
+  /@emotion/sheet/1.2.1:
+    resolution: {integrity: sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==}
+    dev: false
+
+  /@emotion/unitless/0.8.0:
+    resolution: {integrity: sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==}
+    dev: false
+
+  /@emotion/utils/1.2.0:
+    resolution: {integrity: sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==}
+    dev: false
+
+  /@emotion/weak-memoize/0.3.0:
+    resolution: {integrity: sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==}
+    dev: false
 
   /@esbuild/android-arm/0.16.17:
     resolution: {integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==}
@@ -2427,97 +1567,6 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
-  /@linaria/babel-preset/3.0.0-beta.23:
-    resolution: {integrity: sha512-NhxUZokEq12RLpDo4v/f59dB9A/1BbLgGLFotnrDzNBHfylm0qXSIIel68pZOXUB5lVdPJHqZWcT2zxbpGW6fA==}
-    engines: {node: ^12.16.0 || >=13.7.0}
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/generator': 7.20.7
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-commonjs': 7.19.6_@babel+core@7.20.12
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
-      '@linaria/core': 3.0.0-beta.22
-      '@linaria/logger': 3.0.0-beta.20
-      '@linaria/utils': 3.0.0-beta.20
-      cosmiconfig: 5.2.1
-      find-up: 5.0.0
-      source-map: 0.7.4
-      stylis: 3.5.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@linaria/core/3.0.0-beta.22:
-    resolution: {integrity: sha512-BPSecW8QmhQ0y+5cWXEja+MTmLsuo0T1PjqRlSWsmDgjJFFObqCnPEgbR1KNtQb3Msmx1/9q3dYKpA5Zk3g8KQ==}
-    engines: {node: ^12.16.0 || >=13.7.0}
-    dependencies:
-      '@linaria/logger': 3.0.0-beta.20
-      '@linaria/utils': 3.0.0-beta.20
-    transitivePeerDependencies:
-      - supports-color
-
-  /@linaria/logger/3.0.0-beta.20:
-    resolution: {integrity: sha512-wCxWnldCHf7HXdLG3QtbKyBur+z5V1qZTouSEvcVYDfd4aSRPOi/jLdwsZlsUq2PFGpA3jW6JnreZJ/vxuEl7g==}
-    engines: {node: ^12.16.0 || >=13.7.0}
-    dependencies:
-      debug: 4.3.4
-      picocolors: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /@linaria/preeval/3.0.0-beta.23:
-    resolution: {integrity: sha512-TAIN6GPFCahoIH3FHsHk5NM+iaBp5Snniqirk8mailjGGprswl14Z7lgGPzzKZiA5HBzWKW4Wpe1N8W2vSjJTw==}
-    engines: {node: ^12.16.0 || >=13.7.0}
-    dependencies:
-      '@linaria/babel-preset': 3.0.0-beta.23
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@linaria/rollup/3.0.0-beta.23:
-    resolution: {integrity: sha512-qi6lOsMHN3wYfBy3/4kz9bJcK1cPVTThWyfVh8OJxFOdqXi/C8ogT69VobsNVqrng/0REAXYc082m1ovxYGBgA==}
-    engines: {node: ^12.16.0 || >=13.7.0}
-    dependencies:
-      '@linaria/babel-preset': 3.0.0-beta.23
-      '@rollup/pluginutils': 4.2.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@linaria/shaker/3.0.0-beta.23:
-    resolution: {integrity: sha512-kG57X747GM/CqTs+wYx6hMHgzVNt7U/ydh7iO/NwUjIunr359oWwdH2Zjq27xR58TvK9sYXfmFVS8w3IB9fRWQ==}
-    engines: {node: ^12.16.0 || >=13.7.0}
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/generator': 7.20.7
-      '@babel/plugin-transform-runtime': 7.19.6_@babel+core@7.20.12
-      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
-      '@linaria/babel-preset': 3.0.0-beta.23
-      '@linaria/logger': 3.0.0-beta.20
-      '@linaria/preeval': 3.0.0-beta.23
-      babel-plugin-transform-react-remove-prop-types: 0.4.24
-      ts-invariant: 0.10.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@linaria/stylelint/3.0.0-beta.23:
-    resolution: {integrity: sha512-RmnjpLdv3bGk3wyOZ0/pTH7FoZYXVIlI5LspzCo9PJ4ORbvbPGMQqnmhax901PB2Z+Nsa7q5I7ZFmsDRjG+dzQ==}
-    engines: {node: ^12.16.0 || >=13.7.0}
-    dependencies:
-      '@linaria/babel-preset': 3.0.0-beta.23
-      strip-ansi: 5.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@linaria/utils/3.0.0-beta.20:
-    resolution: {integrity: sha512-SKRC9dBApzu0kTksVtGZ7eJz1vMu7xew/JEAjQj6XTQDblzWpTPyKQHBOGXNkqXjIB8PwAqWfvKzKapzaOwQaQ==}
-    engines: {node: ^12.16.0 || >=13.7.0}
-
   /@mapbox/node-pre-gyp/1.0.10:
     resolution: {integrity: sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==}
     hasBin: true
@@ -2563,14 +1612,6 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /@rollup/pluginutils/4.2.1:
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    dev: true
-
   /@sinclair/typebox/0.25.21:
     resolution: {integrity: sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==}
     dev: true
@@ -2587,14 +1628,15 @@ packages:
       '@sinonjs/commons': 2.0.0
     dev: true
 
-  /@stylelint/postcss-css-in-js/0.38.0_postcss-syntax@0.36.2:
+  /@stylelint/postcss-css-in-js/0.38.0_64375vj2stjdn6gyt55zwvoboa:
     resolution: {integrity: sha512-XOz5CAe49kS95p5yRd+DAIWDojTjfmyAQ4bbDlXMdbZTQ5t0ThjSLvWI6JI2uiS7MFurVBkZ6zUqcimzcLTBoQ==}
     peerDependencies:
       postcss: '>=7.0.0'
       postcss-syntax: '>=0.36.2'
     dependencies:
       '@babel/core': 7.20.12
-      postcss-syntax: 0.36.2
+      postcss: 8.4.21
+      postcss-syntax: 0.36.2_postcss@8.4.21
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2710,6 +1752,10 @@ packages:
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
+
+  /@types/parse-json/4.0.0:
+    resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+    dev: false
 
   /@types/prettier/2.7.1:
     resolution: {integrity: sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==}
@@ -3030,24 +2076,6 @@ packages:
       indent-string: 4.0.0
     dev: true
 
-  /ajv-formats/2.1.1:
-    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-    dependencies:
-      ajv: 8.11.2
-    dev: true
-
-  /ajv-keywords/5.1.0_ajv@8.11.2:
-    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
-    peerDependencies:
-      ajv: ^8.8.2
-    dependencies:
-      ajv: 8.11.2
-      fast-deep-equal: 3.1.3
-    dev: true
-
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -3073,11 +2101,6 @@ packages:
       type-fest: 0.21.3
     dev: true
 
-  /ansi-regex/4.1.1:
-    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
-    engines: {node: '>=6'}
-    dev: true
-
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -3096,7 +2119,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       color-convert: 1.9.3
-    dev: true
 
   /ansi-styles/4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -3263,17 +2285,6 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/9.1.2:
-    resolution: {integrity: sha512-mN14niXW43tddohGl8HPu5yfQq70iUThvFL/4QzESA7GcZoC0eVOhvWdQ8+3UlSjaDE9MVtsW9mxDY07W7VpVA==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      '@babel/core': ^7.12.0
-      webpack: '>=5'
-    dependencies:
-      find-cache-dir: 3.3.2
-      schema-utils: 4.0.0
-    dev: true
-
   /babel-plugin-istanbul/6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
@@ -3297,56 +2308,14 @@ packages:
       '@types/babel__traverse': 7.18.2
     dev: true
 
-  /babel-plugin-module-resolver/5.0.0:
-    resolution: {integrity: sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==}
-    engines: {node: '>= 16'}
+  /babel-plugin-macros/3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      find-babel-config: 2.0.0
-      glob: 8.1.0
-      pkg-up: 3.1.0
-      reselect: 4.1.7
+      '@babel/runtime': 7.20.7
+      cosmiconfig: 7.1.0
       resolve: 1.22.1
-    dev: true
-
-  /babel-plugin-polyfill-corejs2/0.3.3_@babel+core@7.20.12:
-    resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.20.10
-      '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.12
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.20.12:
-    resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.12
-      core-js-compat: 3.26.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /babel-plugin-polyfill-regenerator/0.4.1_@babel+core@7.20.12:
-    resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.12
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /babel-plugin-transform-react-remove-prop-types/0.4.24:
-    resolution: {integrity: sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==}
-    dev: true
+    dev: false
 
   /babel-preset-current-node-syntax/1.0.1_@babel+core@7.20.12:
     resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
@@ -3448,29 +2417,9 @@ packages:
       function-bind: 1.1.1
       get-intrinsic: 1.1.3
 
-  /caller-callsite/2.0.0:
-    resolution: {integrity: sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      callsites: 2.0.0
-    dev: true
-
-  /caller-path/2.0.0:
-    resolution: {integrity: sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==}
-    engines: {node: '>=4'}
-    dependencies:
-      caller-callsite: 2.0.0
-    dev: true
-
-  /callsites/2.0.0:
-    resolution: {integrity: sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==}
-    engines: {node: '>=4'}
-    dev: true
-
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /camelcase-keys/6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
@@ -3516,7 +2465,6 @@ packages:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
-    dev: true
 
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -3647,7 +2595,6 @@ packages:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
       color-name: 1.1.3
-    dev: true
 
   /color-convert/2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3658,7 +2605,6 @@ packages:
 
   /color-name/1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-    dev: true
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -3704,10 +2650,6 @@ packages:
       esprima: 4.0.1
       has-own-prop: 2.0.0
       repeat-string: 1.6.1
-    dev: true
-
-  /commondir/1.0.1:
-    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
     dev: true
 
   /compare-func/2.0.0:
@@ -3772,16 +2714,9 @@ packages:
 
   /convert-source-map/1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
-    dev: true
 
   /convert-source-map/2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-    dev: true
-
-  /core-js-compat/3.26.1:
-    resolution: {integrity: sha512-622/KzTudvXCDLRw70iHW4KKs1aGpcRcowGWyYJr2DEBfRrd6hNJybxSWJFuZYD4ma86xhrwDDHxmDaIq4EA8A==}
-    dependencies:
-      browserslist: 4.21.4
     dev: true
 
   /core-util-is/1.0.3:
@@ -3803,15 +2738,16 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /cosmiconfig/5.2.1:
-    resolution: {integrity: sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==}
-    engines: {node: '>=4'}
+  /cosmiconfig/7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
     dependencies:
-      import-fresh: 2.0.0
-      is-directory: 0.3.1
-      js-yaml: 3.14.1
-      parse-json: 4.0.0
-    dev: true
+      '@types/parse-json': 4.0.0
+      import-fresh: 3.3.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.2
+    dev: false
 
   /cosmiconfig/8.0.0:
     resolution: {integrity: sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==}
@@ -4041,7 +2977,6 @@ packages:
 
   /csstype/3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
-    dev: true
 
   /csx/10.0.2:
     resolution: {integrity: sha512-u4Ay+Q7yXQvMtaevcxO9AQ24AP9L4Poym9bLt1gUI1VMJ9czKcfmog+X4j4wSfVHaD0GsXcxpYK7FgH637d5UQ==}
@@ -4297,7 +3232,6 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
-    dev: true
 
   /es-abstract/1.20.4:
     resolution: {integrity: sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==}
@@ -4396,7 +3330,6 @@ packages:
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
-    dev: true
 
   /escape-string-regexp/2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -4406,7 +3339,6 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-    dev: true
 
   /escodegen/2.0.0:
     resolution: {integrity: sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==}
@@ -4741,10 +3673,6 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
-  /estree-walker/2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
-
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -4865,29 +3793,9 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
-  /find-babel-config/2.0.0:
-    resolution: {integrity: sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      json5: 2.2.3
-      path-exists: 4.0.0
-    dev: true
-
-  /find-cache-dir/3.3.2:
-    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
-    engines: {node: '>=8'}
-    dependencies:
-      commondir: 1.0.1
-      make-dir: 3.1.0
-      pkg-dir: 4.2.0
-    dev: true
-
-  /find-up/3.0.0:
-    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
-    engines: {node: '>=6'}
-    dependencies:
-      locate-path: 3.0.0
-    dev: true
+  /find-root/1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+    dev: false
 
   /find-up/4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -5171,7 +4079,6 @@ packages:
   /has-flag/3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
-    dev: true
 
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -5304,21 +4211,12 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /import-fresh/2.0.0:
-    resolution: {integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==}
-    engines: {node: '>=4'}
-    dependencies:
-      caller-path: 2.0.0
-      resolve-from: 3.0.0
-    dev: true
-
   /import-fresh/3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-    dev: true
 
   /import-lazy/4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
@@ -5388,7 +4286,6 @@ packages:
 
   /is-arrayish/0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-    dev: true
 
   /is-bigint/1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
@@ -5420,18 +4317,12 @@ packages:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
-    dev: true
 
   /is-date-object/1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
-    dev: true
-
-  /is-directory/0.3.1:
-    resolution: {integrity: sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /is-extglob/2.1.1:
@@ -6182,11 +5073,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jsesc/0.5.0:
-    resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
-    hasBin: true
-    dev: true
-
   /jsesc/2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
@@ -6199,7 +5085,6 @@ packages:
 
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-    dev: true
 
   /json-schema-traverse/0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -6303,7 +5188,6 @@ packages:
 
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
 
   /lint-staged/13.1.4:
     resolution: {integrity: sha512-pJRmnRA4I4Rcc1k9GZIh9LQJlolCVDHqtJpIgPY7t99XY3uXXmUeDfhRLELYLgUFJPmEsWevTqarex9acSfx2A==}
@@ -6357,14 +5241,6 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /locate-path/3.0.0:
-    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
-    engines: {node: '>=6'}
-    dependencies:
-      p-locate: 3.0.0
-      path-exists: 3.0.0
-    dev: true
-
   /locate-path/5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -6381,10 +5257,6 @@ packages:
 
   /lodash.camelcase/4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-    dev: true
-
-  /lodash.debounce/4.0.8:
-    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
 
   /lodash.isfunction/3.0.9:
@@ -6958,13 +5830,6 @@ packages:
       yocto-queue: 0.1.0
     dev: true
 
-  /p-locate/3.0.0:
-    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      p-limit: 2.3.0
-    dev: true
-
   /p-locate/4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -6996,7 +5861,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
-    dev: true
 
   /parent-module/2.0.0:
     resolution: {integrity: sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==}
@@ -7021,7 +5885,6 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-    dev: true
 
   /parse5-htmlparser2-tree-adapter/7.0.0:
     resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
@@ -7034,11 +5897,6 @@ packages:
     resolution: {integrity: sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==}
     dependencies:
       entities: 4.4.0
-    dev: true
-
-  /path-exists/3.0.0:
-    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
-    engines: {node: '>=4'}
     dev: true
 
   /path-exists/4.0.0:
@@ -7067,7 +5925,6 @@ packages:
 
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
 
   /path-type/3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
@@ -7079,7 +5936,6 @@ packages:
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-    dev: true
 
   /path2d-polyfill/2.0.1:
     resolution: {integrity: sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==}
@@ -7100,6 +5956,7 @@ packages:
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: true
 
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -7135,13 +5992,6 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /pkg-up/3.1.0:
-    resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
-    engines: {node: '>=8'}
-    dependencies:
-      find-up: 3.0.0
-    dev: true
-
   /postcss-media-query-parser/0.2.3:
     resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
     dev: true
@@ -7175,7 +6025,7 @@ packages:
       postcss: 8.4.21
     dev: true
 
-  /postcss-syntax/0.36.2:
+  /postcss-syntax/0.36.2_postcss@8.4.21:
     resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
     peerDependencies:
       postcss: '>=5.0.0'
@@ -7195,6 +6045,8 @@ packages:
         optional: true
       postcss-scss:
         optional: true
+    dependencies:
+      postcss: 8.4.21
     dev: true
 
   /postcss-value-parser/4.2.0:
@@ -7419,26 +6271,8 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /regenerate-unicode-properties/10.1.0:
-    resolution: {integrity: sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      regenerate: 1.4.2
-    dev: true
-
-  /regenerate/1.4.2:
-    resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
-    dev: true
-
   /regenerator-runtime/0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-    dev: true
-
-  /regenerator-transform/0.15.1:
-    resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==}
-    dependencies:
-      '@babel/runtime': 7.20.7
-    dev: true
 
   /regexp.prototype.flags/1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
@@ -7452,29 +6286,6 @@ packages:
   /regexpp/3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
-    dev: true
-
-  /regexpu-core/5.2.2:
-    resolution: {integrity: sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==}
-    engines: {node: '>=4'}
-    dependencies:
-      regenerate: 1.4.2
-      regenerate-unicode-properties: 10.1.0
-      regjsgen: 0.7.1
-      regjsparser: 0.9.1
-      unicode-match-property-ecmascript: 2.0.0
-      unicode-match-property-value-ecmascript: 2.1.0
-    dev: true
-
-  /regjsgen/0.7.1:
-    resolution: {integrity: sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==}
-    dev: true
-
-  /regjsparser/0.9.1:
-    resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
-    hasBin: true
-    dependencies:
-      jsesc: 0.5.0
     dev: true
 
   /repeat-string/1.6.1:
@@ -7496,10 +6307,6 @@ packages:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
     dev: true
 
-  /reselect/4.1.7:
-    resolution: {integrity: sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==}
-    dev: true
-
   /resolve-cwd/3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -7507,15 +6314,9 @@ packages:
       resolve-from: 5.0.0
     dev: true
 
-  /resolve-from/3.0.0:
-    resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==}
-    engines: {node: '>=4'}
-    dev: true
-
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-    dev: true
 
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -7541,7 +6342,6 @@ packages:
       is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: true
 
   /resolve/2.0.0-next.4:
     resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
@@ -7622,16 +6422,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
     dev: false
-
-  /schema-utils/4.0.0:
-    resolution: {integrity: sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==}
-    engines: {node: '>= 12.13.0'}
-    dependencies:
-      '@types/json-schema': 7.0.11
-      ajv: 8.11.2
-      ajv-formats: 2.1.1
-      ajv-keywords: 5.1.0_ajv@8.11.2
-    dev: true
 
   /semver/5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -7762,14 +6552,14 @@ packages:
       source-map: 0.6.1
     dev: true
 
+  /source-map/0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /source-map/0.7.4:
-    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
-    engines: {node: '>= 8'}
     dev: true
 
   /spdx-correct/3.1.1:
@@ -7890,13 +6680,6 @@ packages:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
     dependencies:
       safe-buffer: 5.2.1
-
-  /strip-ansi/5.2.0:
-    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
-    engines: {node: '>=6'}
-    dependencies:
-      ansi-regex: 4.1.1
-    dev: true
 
   /strip-ansi/6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -8034,16 +6817,15 @@ packages:
       - supports-color
     dev: true
 
-  /stylis/3.5.4:
-    resolution: {integrity: sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==}
-    dev: true
+  /stylis/4.1.3:
+    resolution: {integrity: sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==}
+    dev: false
 
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
-    dev: true
 
   /supports-color/7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -8075,7 +6857,6 @@ packages:
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /svg-tags/1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
@@ -8167,7 +6948,6 @@ packages:
   /to-fast-properties/2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
-    dev: true
 
   /to-regex-range/5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -8199,13 +6979,6 @@ packages:
   /trim-newlines/3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
-    dev: true
-
-  /ts-invariant/0.10.3:
-    resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      tslib: 2.4.0
     dev: true
 
   /ts-jest/29.0.5_doipufordlnvh5g4adbwayvyvy:
@@ -8397,29 +7170,6 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
-    dev: true
-
-  /unicode-canonical-property-names-ecmascript/2.0.0:
-    resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /unicode-match-property-ecmascript/2.0.0:
-    resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
-    engines: {node: '>=4'}
-    dependencies:
-      unicode-canonical-property-names-ecmascript: 2.0.0
-      unicode-property-aliases-ecmascript: 2.1.0
-    dev: true
-
-  /unicode-match-property-value-ecmascript/2.1.0:
-    resolution: {integrity: sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /unicode-property-aliases-ecmascript/2.1.0:
-    resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
-    engines: {node: '>=4'}
     dev: true
 
   /unique-string/2.0.0:
@@ -8742,6 +7492,11 @@ packages:
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  /yaml/1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+    dev: false
 
   /yaml/2.2.1:
     resolution: {integrity: sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==}

--- a/renovate.json
+++ b/renovate.json
@@ -34,10 +34,6 @@
       "matchPackagePatterns": ["^react", "^@types/react"]
     },
     {
-      "groupName": "Linaria families",
-      "matchPackagePatterns": ["linaria"]
-    },
-    {
       "groupName": "ESLint families",
       "matchPackagePatterns": ["^eslint", "^@typescript-eslint"]
     },


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

より厳密な monorepo 化をして依存する node モジュールを整理したところ、Linaria と Vite がどうしても噛み合わなくなったため。

### 何を変更したのか

<!-- このPRで何を変更をしたかの概要を記述 -->

#713 で移行した Linaria から Emotion に戻した。

### 技術的にはどこがポイントか

<!-- レビュワーにわかるように、技術的視線での変更概要説明 -->

- highlight.js 用テーマ CSS を読み込む `<link>` 要素を動的に生成して html head に埋め込む workaround は不要となったため、普通に `index.html` にハードコーディングした。

### どこまで動作確認したか

<!-- local や他環境でこのPRの動作確認として何を確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 背景・参考情報

### :bookmark: 関連 URL

## :point_right: チェックポイント

### :construction: TODO リスト 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼ろう　-->

### :warning: 影響範囲

<!--- このPRが影響する範囲を箇条書きで列挙していこう　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
