### PR TITLE
:wrench: `icon` の順序をアルファベット昇順に修正する

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
     sourceType: 'module',
     project: ['./{apps,packages}/**/tsconfig.json'],
   },
-  ignorePatterns: ['.eslintrc.*', 'vite.config.ts', 'dist/**/*', 'typedoc.js'],
+  ignorePatterns: ['.eslintrc.*', 'vite.config.ts', 'dist/**/*', '**/bin/*'],
   plugins: ['react', 'react-hooks'],
   rules: {
     // Enable

--- a/packages/icon/bin/build.js
+++ b/packages/icon/bin/build.js
@@ -6,10 +6,15 @@ import { optimize } from 'svgo';
 import { template } from '../templates/index.js';
 
 async function exec() {
-  const data = await glob('src/*.svg');
+  const targetFiles = await glob('src/*.svg');
+  const sortedTargetFiles = targetFiles.sort((a, b) => {
+    const nameA = a.toLowerCase();
+    const nameB = b.toLowerCase();
+    return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
+  });
 
   const result = await Promise.all(
-    data.map(async (file) => {
+    sortedTargetFiles.map(async (file) => {
       const content = readFileSync(file).toString('utf8');
       const source = await optimize(content);
       const $ = load(source.data.toString(), {


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

`IconName`, `IconElements` の定義順序がランダムになってしまっていたため。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

`icon` パッケージで生成する `IconName` 型および `IconElements` の定義順序をアルファベット昇順になるよう修正を加えた。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

直接の原因は `glob` 関数が返すファイルパス一覧の並び順所。 `v9` からアルファベット降順で返されるようになったため、利用側でソートする必要がある。 `catalog` の codegen はすぐに気付いて修正したが、こちらは漏れてしまっていた。

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->
`icon` をビルドし `catalog` でアルファベット昇順で表示されているのを確認。

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

- [RFE: add sort option (for walk/walkSync methods only) · Issue #497 · isaacs/node-glob](https://github.com/isaacs/node-glob/issues/497)

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
