### PR TITLE
Checkbox コンポーネントの indeterminate と checked の振る舞いを修正する

### DIFF
--- a/packages/core/src/components/inputs/Checkbox/index.story.tsx
+++ b/packages/core/src/components/inputs/Checkbox/index.story.tsx
@@ -4,13 +4,17 @@ import { Checkbox } from '.';
 export const Story = () => {
   const [checked1, setChecked1] = useState(false);
 
-  const [checked2, setChecked2] = useState(false);
+  const [checked2, setChecked2] = useState(true);
 
-  const [indeterminate, setIndeterminate] = useState(false);
+  const [checked3, setChecked3] = useState(false);
+
+  const [indeterminate, setIndeterminate] = useState(true);
 
   const handleChange1 = () => setChecked1((v) => !v);
 
   const handleChange2 = () => setChecked2((v) => !v);
+
+  const handleChange3 = () => setChecked3((v) => !v);
 
   const handleChangeIndeterminate = () => setIndeterminate((v) => !v);
 
@@ -30,7 +34,9 @@ export const Story = () => {
         </Checkbox.Label>
       </li>
       <li>
-        <Checkbox indeterminate={indeterminate} />
+        <Checkbox.Label label={`Checked: ${checked3}`}>
+          <Checkbox checked={checked3} onChange={handleChange3} indeterminate={indeterminate} />
+        </Checkbox.Label>
       </li>
       <li>
         <Checkbox disabled />

--- a/packages/core/src/components/inputs/Checkbox/index.tsx
+++ b/packages/core/src/components/inputs/Checkbox/index.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useEffect, useRef, type ChangeEvent, type ReactNode } from 'react';
+import { useRef, type ChangeEvent, type ReactNode } from 'react';
 import { BorderRadius, Duration, FontSize } from '../../../constants/Style';
 import { cssVar, gutter, square } from '../../../helpers/Style';
 
@@ -27,16 +27,15 @@ type Props = Partial<{
 export const Checkbox = ({ checked, value, disabled, indeterminate = false, onChange }: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const ariaChecked = checked || (indeterminate ? 'mixed' : false);
+  const ariaChecked = indeterminate ? 'mixed' : checked;
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     !disabled && onChange?.(e);
   };
 
-  useEffect(() => {
-    if (!inputRef.current) return;
+  if (inputRef.current) {
     inputRef.current.indeterminate = indeterminate;
-  }, [indeterminate]);
+  }
 
   return (
     <span className={styleBase}>


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

web 標準の振る舞いに準拠することで UI コンポーネントの利便性を担保するため。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

- `indeterminate` と `checked` フラグの両方が `true` の場合は `indeterminate` を優先して UI に反映させるようにした。
  - DOM の標準的な振る舞いはこの様になっている。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
