### PR TITLE
Catalog にある Stories のスクリーンショットをキャプチャするタスクを実装する

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
     sourceType: 'module',
     project: ['./{apps,packages}/**/tsconfig.json'],
   },
-  ignorePatterns: ['.eslintrc.*', 'vite.config.ts', 'dist/**/*', '**/bin/*'],
+  ignorePatterns: ['.eslintrc.*', 'vite.config.ts', 'dist/**/*', '**/bin/*', '*.config.js'],
   plugins: ['react', 'react-hooks'],
   rules: {
     // Enable

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ dist/
 .envrc
 .stylelintcache
 Stories.ts
+__screenshots__

--- a/apps/catalog/bin/capture.js
+++ b/apps/catalog/bin/capture.js
@@ -1,0 +1,48 @@
+// @ts-check
+import playwright from 'playwright';
+
+/**
+ * 接続先となる catalog の URL.
+ */
+const baseUrl = 'http://localhost';
+
+/**
+ * 接続先となる catalog の ポート番号。
+ */
+const port = 3010;
+
+/**
+ * @typedef {'chromium' | 'webkit'} BrowserType
+ * @type {BrowserType[]}
+ */
+const browserTypes = ['chromium', 'webkit'];
+
+async function exec() {
+  const [browserType] = browserTypes;
+  const browser = await playwright[browserType].launch({ headless: true });
+  const page = await browser.newPage();
+
+  await page.goto('http://localhost:3010');
+
+  const locators = await page.locator('ul[role="tree"] a');
+  const count = await locators.count();
+
+  const storyIdList = [];
+
+  for (let i = 0; i < count; i++) {
+    const element = await locators.nth(i);
+    const href = await element.getAttribute('href');
+    storyIdList.push(href?.replace(/\//, ''));
+  }
+
+  for (const storyId of storyIdList) {
+    await page.goto(`http://localhost:3010/preview.html?storyId=${storyId}`, { waitUntil: 'domcontentloaded' });
+    await page.screenshot({
+      path: `__screenshots__/${storyId}.png`,
+    });
+  }
+
+  await browser.close();
+}
+
+exec();

--- a/apps/catalog/bin/capture.js
+++ b/apps/catalog/bin/capture.js
@@ -16,10 +16,10 @@ const baseUrl = 'http://localhost';
 const port = 3010;
 
 /**
- * @typedef {'chromium' | 'webkit'} BrowserType
+ * @typedef {'chromium' | 'webkit' | 'firefox'} BrowserType
  * @type {BrowserType[]}
  */
-const browserTypes = ['chromium', 'webkit'];
+const browserTypes = ['chromium', 'webkit', 'firefox'];
 
 const { browsers, withServer } = await yargs(hideBin(process.argv))
   .option('browsers', {

--- a/apps/catalog/bin/capture.js
+++ b/apps/catalog/bin/capture.js
@@ -1,5 +1,8 @@
 // @ts-check
+import { exec } from 'child_process';
 import playwright from 'playwright';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 /**
  * 接続先となる catalog の URL.
@@ -17,14 +20,111 @@ const port = 3010;
  */
 const browserTypes = ['chromium', 'webkit'];
 
-async function exec() {
+const { browsers, withServer } = await yargs(hideBin(process.argv))
+  .option('browsers', {
+    alias: 'b',
+    type: 'array',
+    choices: browserTypes,
+    default: ['chromium'],
+  })
+  .option('withServer', {
+    type: 'boolean',
+    default: false,
+  })
+  .parseAsync();
+
+async function main() {
+  const serverProcesses = [];
+
+  if (withServer) {
+    for (let i = 0; i < browsers.length; i++) {
+      serverProcesses.push(exec(`pnpm start --port ${port + i}`));
+    }
+    // catalog が起動するまで待つ。
+    await wait(10);
+  }
+
+  const storyIdList = await getStoryIdList(`${baseUrl}:${port}`, 'ul[role="tree"] a');
+
+  await Promise.all(
+    browserTypes.map((browserType) =>
+      captureScreenshotsPerBrowser({
+        browserType,
+        storyIdList,
+      }),
+    ),
+  );
+
+  serverProcesses.forEach((process) => {
+    process.kill();
+  });
+}
+
+/**
+ * 指定のブラウザで対象となる全ての story のスクリーンショットを撮影します。
+ *
+ * @typedef {object} CaptureScreenshotsProps
+ * @property {BrowserType} browserType
+ * @property {string[]} storyIdList
+ *
+ * @param {CaptureScreenshotsProps} props
+ */
+async function captureScreenshotsPerBrowser({ browserType, storyIdList }) {
+  const browserIndex = browserTypes.findIndex((b) => b === browserType);
+  const browser = await playwright[browserType].launch({ headless: true });
+  const page = await browser.newPage();
+
+  for (const storyId of storyIdList) {
+    await captureScreenshot({
+      storyId,
+      browserType,
+      page,
+      url: `${baseUrl}:${port + browserIndex}/preview.html`,
+    });
+  }
+
+  browser.close();
+}
+
+/**
+ * 指定した story のスクリーンショットを撮影します。
+ *
+ * @typedef {object} CaptureScreenshotProps
+ * @property {string} storyId キャプチャする story の ID
+ * @property {string} url
+ * @property {BrowserType} browserType
+ * @property {playwright.Page} page ブラウザのタブに相当する
+ *
+ * @param {CaptureScreenshotProps} props
+ */
+async function captureScreenshot({ storyId, url, browserType, page }) {
+  await page.goto(`${url}?storyId=${storyId}`, { waitUntil: 'load' });
+
+  await page.screenshot({
+    path: `__screenshots__/${browserType}/${storyId}.png`,
+    fullPage: true,
+  });
+}
+
+/**
+ * キャプチャ対象となる story の ID 一覧を取得します。
+ *
+ * @remarks
+ * story の ID は、 catalog のナビゲーションリンクの `href` 値から抽出します。
+ *
+ * @param {string} url
+ * @param {string} selector catalog のナビゲーションを参照できるセレクター。
+ *
+ * @returns storyId の配列
+ */
+async function getStoryIdList(url, selector) {
   const [browserType] = browserTypes;
   const browser = await playwright[browserType].launch({ headless: true });
   const page = await browser.newPage();
 
-  await page.goto('http://localhost:3010');
+  await page.goto(url);
 
-  const locators = await page.locator('ul[role="tree"] a');
+  const locators = await page.locator(selector);
   const count = await locators.count();
 
   const storyIdList = [];
@@ -32,17 +132,30 @@ async function exec() {
   for (let i = 0; i < count; i++) {
     const element = await locators.nth(i);
     const href = await element.getAttribute('href');
+
+    if (href === null) {
+      continue;
+    }
+
     storyIdList.push(href?.replace(/\//, ''));
   }
 
-  for (const storyId of storyIdList) {
-    await page.goto(`http://localhost:3010/preview.html?storyId=${storyId}`, { waitUntil: 'domcontentloaded' });
-    await page.screenshot({
-      path: `__screenshots__/${storyId}.png`,
-    });
-  }
+  browser.close();
 
-  await browser.close();
+  return storyIdList;
 }
 
-exec();
+/**
+ * 指定の時間（秒）だけ待ちます。
+ *
+ * @param {number} sec 秒
+ */
+function wait(sec) {
+  return new Promise((result) => {
+    setTimeout(() => {
+      result(undefined);
+    }, sec * 1000);
+  });
+}
+
+main();

--- a/apps/catalog/bin/capture.js
+++ b/apps/catalog/bin/capture.js
@@ -3,6 +3,7 @@ import { exec } from 'child_process';
 import playwright from 'playwright';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import config from '../capture.config.js';
 
 /**
  * 接続先となる catalog の URL.
@@ -44,7 +45,11 @@ async function main() {
     await wait(10);
   }
 
-  const storyIdList = await getStoryIdList(`${baseUrl}:${port}`, 'ul[role="tree"] a');
+  const storyIdList = await getStoryIdList(`${baseUrl}:${port}`, 'ul[role="tree"] a').then((list) =>
+    list.filter((storyId) => !config.ignoreStoryIdList.includes(storyId)),
+  );
+
+  console.info({ Browsers: browserTypes, Found: `${storyIdList.length} stories` });
 
   await Promise.all(
     browserTypes.map((browserType) =>
@@ -99,11 +104,14 @@ async function captureScreenshotsPerBrowser({ browserType, storyIdList }) {
  */
 async function captureScreenshot({ storyId, url, browserType, page }) {
   await page.goto(`${url}?storyId=${storyId}`, { waitUntil: 'load' });
+  const path = `__screenshots__/${browserType}/${storyId}.png`;
 
   await page.screenshot({
-    path: `__screenshots__/${browserType}/${storyId}.png`,
+    path,
     fullPage: true,
   });
+
+  console.info(`📸 ${path}`);
 }
 
 /**

--- a/apps/catalog/capture.config.js
+++ b/apps/catalog/capture.config.js
@@ -1,0 +1,3 @@
+export default {
+  ignoreStoryIdList: ['core__src__components__dataDisplay__PDFViewer', 'core__src__components__feedback__Preloader'],
+};

--- a/apps/catalog/package.json
+++ b/apps/catalog/package.json
@@ -9,7 +9,7 @@
     "type-check": "tsc --noEmit",
     "start": "run-p \"generate --watch\" \"type-check --watch\" \"develop {@}\" --",
     "build": "pnpm generate && pnpm type-check && vite build",
-    "capture": "node ./bin/capture.js",
+    "capture": "rm -rf ./__screenshots__ && node ./bin/capture.js",
     "preview": "vite preview",
     "deploy": "bash ./bin/sync-s3.sh"
   },

--- a/apps/catalog/package.json
+++ b/apps/catalog/package.json
@@ -9,6 +9,7 @@
     "type-check": "tsc --noEmit",
     "start": "run-p \"generate --watch\" \"type-check --watch\" \"develop {@}\" --",
     "build": "pnpm generate && pnpm type-check && vite build",
+    "capture": "node ./bin/capture.js",
     "preview": "vite preview",
     "deploy": "bash ./bin/sync-s3.sh"
   },
@@ -31,6 +32,7 @@
     "chokidar": "3.5.3",
     "glob": "10.2.2",
     "npm-run-all": "4.1.5",
+    "playwright": "1.33.0",
     "typescript": "5.0.4",
     "vite": "4.3.3",
     "yargs": "17.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       npm-run-all:
         specifier: 4.1.5
         version: 4.1.5
+      playwright:
+        specifier: 1.33.0
+        version: 1.33.0
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -6279,6 +6282,21 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 4.1.0
+    dev: true
+
+  /playwright-core@1.33.0:
+    resolution: {integrity: sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
+  /playwright@1.33.0:
+    resolution: {integrity: sha512-+zzU3V2TslRX2ETBRgQKsKytYBkJeLZ2xzUj4JohnZnxQnivoUvOvNbRBYWSYykQTO0Y4zb8NwZTYFUO+EpPBQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      playwright-core: 1.33.0
     dev: true
 
   /postcss-media-query-parser@0.2.3:


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

reg-suit を使った VRT を導入するため。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

Catalog にある Stories のスクリーンショットをキャプチャするタスク（スクリプト）を実装した。キャプチャしたスクリーンショットは `apps/catalog/__screenshots` ディレクトリ配下に保存される。

キャプチャする際のブラウザは `chromium`, `webkit`, `firefox` の中から複数選択できる。

`capture.config.js` の `ignoreStoryIdList` フィールドに列挙した story はキャプチャの対象外となる。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

[Playwright](https://playwright.dev/) を使って実装した。Node.js の `child_process` 上で Catalog を起動し、それらに対し Playwright のブラウザからアクセスして各 story のスクリーンショットをキャプチャする。キャプチャ処理はブラウザ別に並列で実行している。

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

今後モバイルサイズとデスクトップサイズそれぞれでキャプチャすることになったら、これらも並列で実行できるように改修する。

`PDFViewer` は現段階ではキャプチャの対象外としている。この story が完全に表示表示されるまで 1s 以上要するのだが、現在は story ごとにキャプチャ前の待機時間を設定できない。そのためこの story をキャプチャするには全 story に対し一律で待機せねばならず、それでは CI の時間が長大となる。従って story ごとに待機時間が設定できるようになるまで対象外とした。

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
