### PR TITLE
useClickOutside を実装する

### DIFF
--- a/packages/core/src/hooks/useClickOutside/index.story.tsx
+++ b/packages/core/src/hooks/useClickOutside/index.story.tsx
@@ -8,7 +8,7 @@ export const Story = () => {
 
   const [count, setCount] = useState(0);
 
-  const handleClickOutside = (event: MouseEvent) => {
+  const handleClickOutside = (event: Event) => {
     setCount((count) => count + 1);
 
     console.info(`outside was clicked`, event);

--- a/packages/core/src/hooks/useClickOutside/index.story.tsx
+++ b/packages/core/src/hooks/useClickOutside/index.story.tsx
@@ -1,0 +1,72 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+import { useClickOutside } from '.';
+import { cssVar, gutter, square } from '../../helpers/Style';
+
+export const Story = () => {
+  const [enabled, setEnabled] = useState(true);
+
+  const [count, setCount] = useState(0);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    setCount((count) => count + 1);
+
+    console.info(`outside was clicked`, event);
+  };
+
+  const ref = useClickOutside<HTMLDivElement>(handleClickOutside, enabled);
+
+  const handleToggleEnabled = () => {
+    setEnabled(!enabled);
+  };
+
+  return (
+    <div className={styleRoot}>
+      <div className={styleOutside}>
+        <div ref={ref} className={styleInside}>
+          Inside
+        </div>
+      </div>
+
+      <p>
+        Count: <b>{count}</b>
+      </p>
+
+      <label className={styleLabel}>
+        <input type="checkbox" checked={enabled} onChange={handleToggleEnabled} />
+        Enabled
+      </label>
+    </div>
+  );
+};
+
+const styleRoot = css`
+  display: flex;
+  flex-direction: column;
+  gap: ${gutter(4)};
+`;
+
+const styleOutside = css`
+  display: grid;
+  place-content: center;
+  background-color: ${cssVar('TexturePale')};
+  border: 1px solid ${cssVar('LineLight')};
+
+  ${square(240)}
+`;
+
+const styleInside = css`
+  display: grid;
+  place-content: center;
+  color: ${cssVar('TextNeutral')};
+  background-color: ${cssVar('TextureBody')};
+  border: 1px solid ${cssVar('LineNeutral')};
+
+  ${square(120)}
+`;
+
+const styleLabel = css`
+  display: flex;
+  gap: ${gutter(1)};
+  align-items: center;
+`;

--- a/packages/core/src/hooks/useClickOutside/index.ts
+++ b/packages/core/src/hooks/useClickOutside/index.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+/**
+ * ある要素の領域外をクリックしたイベントを検知します。
+ *
+ * @param callback - 領域外をクリックした時に発火するコールバック関数
+ * @param enabled - 有効化フラグ ( default: true )
+ *
+ * @returns 領域（起点）となる要素。
+ *
+ * @example
+ * ```tsx
+ * const ref = useClickOutside<HTMLDivElement>(() => {
+ *   console.info('clicked outside!');
+ * });
+ *
+ * return <div ref={ref}>Inner area</div>;
+ * ```
+ */
+export function useClickOutside<T extends HTMLElement>(
+  callback: (event: MouseEvent) => void,
+  enabled = true,
+): RefObject<T> {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const args = [
+      'click',
+      (event: MouseEvent) => {
+        !ref.current?.contains(event.target as HTMLElement) && callback(event);
+      },
+    ] as const;
+
+    if (enabled) {
+      document.addEventListener(...args);
+    }
+
+    return () => {
+      document.removeEventListener(...args);
+    };
+  }, [callback, enabled]);
+
+  return ref;
+}

--- a/packages/core/src/hooks/useClickOutside/index.ts
+++ b/packages/core/src/hooks/useClickOutside/index.ts
@@ -17,26 +17,22 @@ import { useEffect, useRef, type RefObject } from 'react';
  * return <div ref={ref}>Inner area</div>;
  * ```
  */
-export function useClickOutside<T extends HTMLElement>(
-  callback: (event: MouseEvent) => void,
-  enabled = true,
-): RefObject<T> {
+export function useClickOutside<T extends HTMLElement>(callback: (event: Event) => void, enabled = true): RefObject<T> {
   const ref = useRef<T>(null);
 
   useEffect(() => {
-    const args = [
-      'click',
-      (event: MouseEvent) => {
-        !ref.current?.contains(event.target as HTMLElement) && callback(event);
-      },
-    ] as const;
+    const listener = (event: Event) => {
+      !ref.current?.contains(event.target as HTMLElement) && callback(event);
+    };
 
     if (enabled) {
-      document.addEventListener(...args);
+      document.addEventListener('click', listener);
+      document.addEventListener('touchstart', listener);
     }
 
     return () => {
-      document.removeEventListener(...args);
+      document.removeEventListener('click', listener);
+      document.removeEventListener('touchstart', listener);
     };
   }, [callback, enabled]);
 

--- a/packages/icon/src/dashboard.svg
+++ b/packages/icon/src/dashboard.svg
@@ -1,3 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M3 3H11V13H3V3ZM21 3H13V9H21V3ZM9 11V5H5V11H9ZM19 7V5H15V7H19ZM19 13V19H15V13H19ZM9 19V17H5V19H9ZM21 11H13V21H21V11ZM3 15H11V21H3V15Z" />
+<svg viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#clip0_1_2)">
+    <path d="M12 52H44V12H12V52ZM12 84H44V60H12V84ZM52 84H84V44H52V84ZM52 12V36H84V12H52Z" />
+  </g>
+  <defs>
+    <clipPath id="clip0_1_2">
+      <rect width="96" height="96" />
+    </clipPath>
+  </defs>
 </svg>


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

現在の `Popover` はコンテンツの背景に透明 div によるオーバーレイが敷かれている。これは Popover を閉じるためのクリックイベントをリッスンするために存在しているものだが、これがある影響でオーバーレイの後ろにある要素のクリックと Popover を閉じる処理を同時に発火できない。これではユーザーの体験として直感性に反するため、オーバーレイ無しに Popover コンテンツを領域外クリックで閉じれるようにする必要がある。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

任意の要素外クリックをキャプチャするカスタムフックを実装した。戻り値である `RefObject` を持たせた要素の外をクリックすると、引数に渡したコールバック関数が発火する。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
