### PR TITLE
export されている type alias の JSDoc を必須化する

### DIFF
--- a/eslint-rules/jsdoc.cjs
+++ b/eslint-rules/jsdoc.cjs
@@ -15,6 +15,12 @@ module.exports = {
         definedTags: ['remarks', 'typeParam'],
       },
     ],
+    'jsdoc/require-description': [
+      'error',
+      {
+        contexts: ['TSInterfaceDeclaration', 'TSTypeAliasDeclaration', 'TSPropertySignature', 'TSMethodSignature'],
+      },
+    ],
     'jsdoc/require-hyphen-before-param-description': ['error', 'always'],
     'jsdoc/require-jsdoc': [
       'error',
@@ -28,6 +34,7 @@ module.exports = {
           FunctionExpression: true,
           MethodDefinition: true,
         },
+        contexts: ['TSInterfaceDeclaration', 'TSTypeAliasDeclaration', 'TSPropertySignature', 'TSMethodSignature'],
         checkConstructors: false,
       },
     ],


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

internal なものはまだしも export されている type alias に JSDoc が記載されていないのはドキュメンテーション化する上で見逃しておけない。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

export されている type alias に対し JSDoc の記述を強制するよう lint rules を修正した。これにより対象となる type alias そのものは勿論、中身のプロパティに対する JSDoc も記述対象となる。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

`require-jsdoc` と `require-description` の `contexts` プロパティに type alias や interface を指す AST 名を追加した。これにより TypeScript の type alias, interface が監視対象となる。

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

UI コンポーネントの `Props` は原則 internal なので対象外。これらを対象に含めようとすると他のローカル関数も対象に含まれてしまうため、やむなく対象外とする。

## :classical_building: 参考文献

- [exportしているモジュールのJSDocやTSDocを必須にする - 毎日へっぽこ](https://hepokon365.hatenablog.com/entry/2022/08/17/081732#%E5%85%AC%E9%96%8B%E3%81%95%E3%82%8C%E3%81%9Fclass%E3%81%AE%E3%83%97%E3%83%AD%E3%83%91%E3%83%86%E3%82%A3%E3%82%84typeinterface%E3%81%A7%E3%81%AEJSDocTSDoc%E5%BF%85%E9%A0%88%E5%8C%96)

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
