### PR TITLE
ESLint と Prettier の設定を修正する

### DIFF
--- a/eslint-rules/react.cjs
+++ b/eslint-rules/react.cjs
@@ -220,7 +220,7 @@ module.exports = {
         exceptions: [],
       },
     ],
-    'react/prefer-read-only-props': ['error'],
+    // 'react/prefer-read-only-props': ['error'],
     'react/jsx-no-script-url': [
       'error',
       [

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,3 @@
-import organizeImports from 'prettier-plugin-organize-imports';
-
 export default {
   printWidth: 120, // Extend from default (80) to prevent excessive line breaks.
   // tabWidth: 2,
@@ -8,7 +6,7 @@ export default {
   singleQuote: true, // Change from default (false) because it's easier to type and read than double-quote.
   // quoteProps: 'as-needed',
   // jsxSingleQuote: false,
-  trailingComma: 'all', // To facilitate reordering object properties.
+  // trailingComma: 'all',
   // bracketSpacing: true,
   // bracketSameLine: false,
   // arrowParens: 'always',
@@ -25,5 +23,5 @@ export default {
   // embeddedLanguageFormatting: 'auto',
   // singleAttributePerLine: false,
 
-  plugins: [organizeImports],
+  plugins: ['prettier-plugin-organize-imports'],
 };


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

- ESLint Plugin React のうち不要なルールが有効化されていた。
- VSCode の Format on save で Prettier が機能していなかった。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

#### ESLint
`eslint-plugin-react` にある `prefer-read-only-props` を無効化した。これは Props 型のフィールドすべてに対し `readonly` を付与するルールだが、そこまで厳密にせずとも prop に再代入しようとした時点で React がランタイムエラーを出すので不要。

#### Prettier

Prettier Plugin の読み込み方式を Prettier v3 向けに書き直した。これにより VSCode の `formatOnSave` で Prettier が適切に適用されるようになった。

`trailingComma` を未指定にした。 Prettier v3 よりデフォルト値が `all` となったため、明示的に指定する必要がなくなったため。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
