### PR TITLE
ESLint のルールにあった抜け漏れを改修する

### DIFF
--- a/eslint-rules/best-practices.cjs
+++ b/eslint-rules/best-practices.cjs
@@ -94,7 +94,7 @@ module.exports = {
     'no-empty-function': [
       'error',
       {
-        allow: ['arrowFunctions', 'functions', 'methods'],
+        allow: ['arrowFunctions', 'functions', 'methods', 'constructors'],
       },
     ],
 

--- a/eslint-rules/imports.cjs
+++ b/eslint-rules/imports.cjs
@@ -121,8 +121,8 @@ module.exports = {
 
     // ensure absolute imports are above relative imports and that unassigned imports are ignored
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
-    // TODO: enforce a stricter convention in module import order?
-    'import/order': ['error', { groups: [['builtin', 'external', 'internal']] }],
+    // prettier-plugin-organize-imports に委譲するため無効化する。
+    'import/order': ['off'],
 
     // Require a newline after the last import/require in a group
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

- airbnb のプリセットを流用したものの中に `import/order` ルールが入っており、これが Prettier と競合していた。
- 空のコンストラクタメソッドを対象外にしそびれていた。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

- `import/order` ルールを無効化し、Prettier に完全委譲した。
- コストラクタメソッド内は中身が空でも許容するようにした。
  - メンバー変数の定義のためだけに記述するケースがあるため。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
