### PR TITLE
TypeScript ESLint ルールをアップデートする

### DIFF
--- a/apps/esnext/src/generator/api-client.ts
+++ b/apps/esnext/src/generator/api-client.ts
@@ -51,7 +51,7 @@ async function request<ResponseType>(url: string): Promise<ResponseType> {
     method: 'GET',
   });
   if (!res.ok) {
-    await res.json().catch((err) => {
+    await res.json().catch((err: unknown) => {
       console.info('ここでエラー処理をしてください');
       throw new Error(err as string);
     });

--- a/eslint-rules/typescript.js
+++ b/eslint-rules/typescript.js
@@ -103,24 +103,23 @@ const recommendTypeScript = {
     '@typescript-eslint/no-explicit-any': ['off', { ignoreRestArgs: true }],
 
     // https://typescript-eslint.io/rules/no-unsafe-assignment/
-    // TODO: Enable as "warn".
-    // '@typescript-eslint/no-unsafe-assignment': ['warn'],
+    '@typescript-eslint/no-unsafe-assignment': ['warn'],
 
     // https://typescript-eslint.io/rules/no-unsafe-call/
-    // TODO: Enable as "warn".
-    // '@typescript-eslint/no-unsafe-call': ['warn'],
+    '@typescript-eslint/no-unsafe-call': ['warn'],
 
     // https://typescript-eslint.io/rules/no-unsafe-argument/
-    // TODO: Enable as "warn".
-    // '@typescript-eslint/no-unsafe-argument': ['warn'],
+    '@typescript-eslint/no-unsafe-argument': ['warn'],
 
     // https://typescript-eslint.io/rules/no-unsafe-member-access/
-    // TODO: Enable as "warn".
-    // '@typescript-eslint/no-unsafe-member-access': ['warn'],
+    '@typescript-eslint/no-unsafe-member-access': ['warn'],
 
     // https://typescript-eslint.io/rules/non-nullable-type-assertion-style/
     // You should use type assertion style "as" instead of non-null assertion style.
     '@typescript-eslint/non-nullable-type-assertion-style': ['off'],
+
+    // https://typescript-eslint.io/rules/only-throw-error/
+    '@typescript-eslint/only-throw-error': ['off'],
   },
 };
 

--- a/packages/try/src/Suspense/api.ts
+++ b/packages/try/src/Suspense/api.ts
@@ -46,13 +46,13 @@ function request<REQ extends Record<string, unknown>, RES>({
             .then((data: RES) => {
               resolve(data);
             })
-            .catch((error) => {
+            .catch((error: unknown) => {
               console.error(error);
               reject(error);
             });
         }
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         console.error(error);
         reject(error);
       });

--- a/packages/try/src/Transition2/common/Api.ts
+++ b/packages/try/src/Transition2/common/Api.ts
@@ -37,13 +37,13 @@ function request<REQ extends Record<string, unknown>, RES>({
             .then((data: RES) => {
               resolve(data);
             })
-            .catch((error) => {
+            .catch((error: unknown) => {
               console.error(error);
               reject(error);
             });
         }
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         console.error(error);
         reject(error);
       });


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

`@typescript-eslint` を v6.21 から v7 にアップデートしたことにで新ルールが追加され、これに引っかかった。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

- `@typescript-eslint/only-throw-error` ルールを無効化した。
- 以下のルールを `error` から `warn` に変更した:
  - `@typescript-eslint/no-unsafe-assignment`
  - `@typescript-eslint/no-unsafe-call`
  - `@typescript-eslint/no-unsafe-argument`
  - `@typescript-eslint/no-unsafe-member-access`

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
