### PR TITLE
date-fns から Tempo に移行する

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -70,6 +70,7 @@
     "linebreaks",
     "nonblock",
     "nonwords",
-    "stylelintrc"
+    "stylelintrc",
+    "formkit"
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "@emotion/css": "11.11.2",
+    "@formkit/tempo": "0.1.2",
     "@learn-react/icon": "workspace:1.0.0",
     "constate": "3.3.2",
     "csx": "10.0.2",
-    "date-fns": "3.6.0",
     "hotkeys-js": "3.13.7",
     "pdfjs-dist": "4.4.168",
     "qs": "6.12.3",

--- a/packages/core/src/components/inputs/Calendar/index.tsx
+++ b/packages/core/src/components/inputs/Calendar/index.tsx
@@ -1,18 +1,6 @@
 import { css } from '@emotion/css';
-import {
-  addMonths,
-  endOfDay,
-  format,
-  isAfter,
-  isBefore,
-  isSameDay,
-  lastDayOfMonth,
-  setDate,
-  startOfDay,
-  startOfMonth,
-  subMonths,
-} from 'date-fns';
-import { useMemo, type ChangeEvent } from 'react';
+import { addMonth, dayEnd, dayStart, format, isAfter, isBefore, monthEnd, monthStart, sameDay } from '@formkit/tempo';
+import { type ChangeEvent } from 'react';
 import { FontSize } from '../../../constants/Style';
 import { cssVar, gutter } from '../../../helpers/Style';
 import { IconButton } from '../IconButton';
@@ -56,22 +44,22 @@ export const Calendar = ({
   onChangeDate,
   onChangeMonth,
 }: Props) => {
-  const page = useMemo(() => startOfMonth(rawPage), [rawPage]);
+  const page = monthStart(rawPage);
 
-  const maxDate = useMemo(() => rawMaxDate && endOfDay(rawMaxDate), [rawMaxDate]);
+  const maxDate = rawMaxDate && dayEnd(rawMaxDate);
 
-  const minDate = useMemo(() => rawMinDate && startOfDay(rawMinDate), [rawMinDate]);
+  const minDate = rawMinDate && dayStart(rawMinDate);
 
   const handleClickDate = (value: Date) => {
-    onChangeDate?.(startOfDay(value));
+    onChangeDate?.(dayStart(value));
   };
 
   const handleClickPrevMonth = () => {
-    onChangeMonth?.(subMonths(page, 1));
+    onChangeMonth?.(addMonth(page, -1));
   };
 
   const handleClickNextMonth = () => {
-    onChangeMonth?.(addMonths(page, 1));
+    onChangeMonth?.(addMonth(page, 1));
   };
 
   const handleChangeYearMonth = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -110,7 +98,7 @@ export const Calendar = ({
                 <td key={j}>
                   <Item
                     value={cell}
-                    active={cell ? isSameDay(cell, value) : undefined}
+                    active={cell ? sameDay(cell, value) : undefined}
                     disabled={
                       cell ? (maxDate && isAfter(cell, maxDate)) ?? (minDate && isBefore(cell, minDate)) : undefined
                     }
@@ -169,7 +157,7 @@ const yearGroup = [...Array(31).keys()].map((year) => ({
   months: [...Array(12).keys()].map((month) => {
     const d = new Date(2000 + year, month);
     return {
-      label: format(d, 'MMM yyyy'),
+      label: format(d, 'MMM YYYY', 'en'),
       value: d.getTime(),
     };
   }),
@@ -195,9 +183,11 @@ const WeekLabels = ['日', '月', '火', '水', '木', '金', '土'] as const;
  * ```
  */
 function getDateArray(page: Date): (Date | undefined)[][] {
-  const padStart = new Array<undefined>(setDate(page, 1).getDay()).fill(undefined);
+  const padStart = new Array<undefined>(monthStart(page).getDay()).fill(undefined);
 
-  const dates = [...Array(lastDayOfMonth(page).getDate()).keys()].map((i) => setDate(page, i + 1));
+  const dates = [...Array(monthEnd(page).getDate()).keys()].map(
+    (i) => new Date(page.getFullYear(), page.getMonth(), i + 1),
+  );
 
   const headLength = (padStart.length + dates.length) % 7 || 7;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       '@emotion/css':
         specifier: 11.11.2
         version: 11.11.2
+      '@formkit/tempo':
+        specifier: 0.1.2
+        version: 0.1.2
       '@learn-react/icon':
         specifier: workspace:1.0.0
         version: link:../icon
@@ -288,9 +291,6 @@ importers:
       csx:
         specifier: 10.0.2
         version: 10.0.2
-      date-fns:
-        specifier: 3.6.0
-        version: 3.6.0
       hotkeys-js:
         specifier: 3.13.7
         version: 3.13.7
@@ -1146,6 +1146,9 @@ packages:
   '@eslint/js@8.57.0':
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@formkit/tempo@0.1.2':
+    resolution: {integrity: sha512-jNPPbjL8oj7hK3eHX++CwbR6X4GKQt+x00/q4yeXkwynXHGKL27dylYhpEgwrmediPP4y7s0XtN1if/M/JYujg==}
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -2014,9 +2017,6 @@ packages:
   data-view-byte-offset@1.0.0:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
-
-  date-fns@3.6.0:
-    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -5089,6 +5089,8 @@ snapshots:
 
   '@eslint/js@8.57.0': {}
 
+  '@formkit/tempo@0.1.2': {}
+
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -6130,8 +6132,6 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
-
-  date-fns@3.6.0: {}
 
   debug@3.2.7:
     dependencies:


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

date-fns は十分に慣れ親しんでおり、 `Intl.DateTimeFormat` と親和性の高いユーティリティライブラリーの知見を得ておきたい。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

`Calendar` コンポーネントの内部実装に用いている [`date-fns`](https://date-fns.org/) を [`@formkit/tempo`](https://tempo.formkit.com/) に置き換えた。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

殆どのユーティリティメソッドは名称と機能が同一、もしくは名称のみ異なるだけだったため、コードに修正を加えることなく置き換えられた。以下は `date-fns` と `@formkit/tempo` の対比表。

|`date-fns`|`@formkit/tempo`|特記事項|
|:---|---|---|
| `addMonths` | `addMonth` | |
| `endOfDay` | `dayEnd` | |
| `format` | `format` | フォーマットスタイルの仕様が異なるため、 `tempo` の仕様に調整。 |
| `isAfter` | `isAfter` | |
| `isBefore` | `isBefore` | |
| `isSameDay` | `sameDay` | |
| `lastDayOfMonth` | `monthEnd` | |
| `setDate` | `--` | 同等のメソッドが存在しないため、 `new Date()` を使って愚直に実装。 |
| `startOfDay` | `dayStart` | |
| `startOfMonth` | `monthStart` | |
| `subMonths` | `--` | `addMonth` の第二引数に負の値を渡すことで代替。 |

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

不要な `useMemo` が散見されたため、ついでにそれらを除去した。

## :classical_building: 参考文献

- #1562 
- [Tempo • Dates by FormKit](https://tempo.formkit.com/)

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
