### PR TITLE
`doc` パッケージのビルドスクリプトを修正する

### DIFF
--- a/apps/doc/bin/typedoc.js
+++ b/apps/doc/bin/typedoc.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { dirname, resolve } from 'path';
-import TypeDoc from 'typedoc';
+import TypeDoc, { Application } from 'typedoc';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
@@ -23,11 +23,7 @@ const workspace = name === 'core' ? 'packages' : 'apps';
 console.info({ name, watch });
 
 async function main() {
-  const app = new TypeDoc.Application();
-
-  app.options.addReader(new TypeDoc.TSConfigReader());
-
-  app.bootstrap({
+  const app = await Application.bootstrap({
     watch,
     entryPoints: [resolve(__dirname, `../../../${workspace}/${name}`)],
     exclude: [resolve(__dirname, '../../**/*.(test|story).tsx')],
@@ -38,10 +34,11 @@ async function main() {
     entryPointStrategy: 'expand',
     excludeExternals: true,
     name: `@learn-react/${name}`,
-    theme: 'hierarchy',
   });
 
-  const project = app.convert();
+  app.options.addReader(new TypeDoc.TSConfigReader());
+
+  const project = await app.convert();
 
   if (!project) return;
 

--- a/apps/doc/package.json
+++ b/apps/doc/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {
     "typedoc": "0.26.4",
     "typedoc-plugin-missing-exports": "3.0.0",
-    "typedoc-theme-hierarchy": "5.0.3",
     "typescript": "5.5.3",
     "yargs": "17.7.2"
   }

--- a/apps/doc/public/index.html
+++ b/apps/doc/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
@@ -14,6 +14,9 @@
       </li>
       <li>
         <a href="/core/">@learn-react/core</a>
+      </li>
+      <li>
+        <a href="/statement/">@learn-react/statement</a>
       </li>
     </ul>
   </body>

--- a/packages/core/src/ambience.d.ts
+++ b/packages/core/src/ambience.d.ts
@@ -26,6 +26,11 @@ declare module '*.woff' {
   export default exports;
 }
 
+declare module '*?url' {
+  const content: string;
+  export default content;
+}
+
 declare type XOR<T, U> = import('ts-xor').XOR<T, U>;
 
 declare type ValueOf<T> = T[keyof T];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,6 @@ importers:
       typedoc-plugin-missing-exports:
         specifier: 3.0.0
         version: 3.0.0(typedoc@0.26.4(typescript@5.5.3))
-      typedoc-theme-hierarchy:
-        specifier: 5.0.3
-        version: 5.0.3(typedoc@0.26.4(typescript@5.5.3))
       typescript:
         specifier: 5.5.3
         version: 5.5.3
@@ -2474,10 +2471,6 @@ packages:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
 
-  fs-extra@11.1.1:
-    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
-    engines: {node: '>=14.14'}
-
   fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
@@ -2943,9 +2936,6 @@ packages:
 
   jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
-
-  jsonfile@6.1.0:
-    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -4027,11 +4017,6 @@ packages:
     peerDependencies:
       typedoc: 0.26.x
 
-  typedoc-theme-hierarchy@5.0.3:
-    resolution: {integrity: sha512-88ItQMqVCb/QstNsP3i18tNp7NvQb1fTCFcHmte56pm6FCeMHzemP9AilRu3MYqfu1FM9FX8QsLl6gDzUxKTDg==}
-    peerDependencies:
-      typedoc: ^0.26.0
-
   typedoc@0.26.4:
     resolution: {integrity: sha512-FlW6HpvULDKgc3rK04V+nbFyXogPV88hurarDPOjuuB5HAwuAlrCMQ5NeH7Zt68a/ikOKu6Z/0hFXAeC9xPccQ==}
     engines: {node: '>= 18'}
@@ -4063,10 +4048,6 @@ packages:
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
-
-  universalify@2.0.0:
-    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
-    engines: {node: '>= 10.0.0'}
 
   update-browserslist-db@1.0.11:
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
@@ -6750,12 +6731,6 @@ snapshots:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
-  fs-extra@11.1.1:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.0
-
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.5
@@ -7206,12 +7181,6 @@ snapshots:
   json5@2.2.3: {}
 
   jsonc-parser@3.2.0: {}
-
-  jsonfile@6.1.0:
-    dependencies:
-      universalify: 2.0.0
-    optionalDependencies:
-      graceful-fs: 4.2.11
 
   jsonparse@1.3.1: {}
 
@@ -8313,11 +8282,6 @@ snapshots:
     dependencies:
       typedoc: 0.26.4(typescript@5.5.3)
 
-  typedoc-theme-hierarchy@5.0.3(typedoc@0.26.4(typescript@5.5.3)):
-    dependencies:
-      fs-extra: 11.1.1
-      typedoc: 0.26.4(typescript@5.5.3)
-
   typedoc@0.26.4(typescript@5.5.3):
     dependencies:
       lunr: 2.3.9
@@ -8345,8 +8309,6 @@ snapshots:
   unicorn-magic@0.1.0: {}
 
   universalify@0.2.0: {}
-
-  universalify@2.0.0: {}
 
   update-browserslist-db@1.0.11(browserslist@4.21.10):
     dependencies:


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

`typedoc` のアップデートにより `apps/doc` のビルドが失敗するようになっていたため。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

- `typedoc` を使ったビルドスクリプトを修正した。
- Vite の URL インポートによる TypeScript エラーを回避した。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

- `typedoc` の `Application` クラスの仕様にあわせてビルドスクリプトを修正した。
- typedoc theme plugin の読み込みエラーを解消できなかったので、やむなく `hierarchy` プラグインをアンインストールし、 `default` テーマを使うようにした。
- Vite の機能を用いた URL インポートを TypeScript がエラーと検知しないように アンビエント宣言 (`declare module` ) を追加した。

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

- [Application | TypeDoc - v0.26.4](https://typedoc.org/api/classes/Application.html)
- [静的アセットの取り扱い | Vite](https://ja.vitejs.dev/guide/assets#explicit-url-imports)

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
