### PR TITLE
chore(builder): allow fetching from splitted stories

### DIFF
--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -58,6 +58,7 @@ export function createUserConfig({ basePath, port = 3000, define = {}, build = {
       port,
       host: true,
       open: true,
+      cors: true,
     },
     resolve: {
       alias,


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

`@learn-react/catalog` にて stories を `iframe` で読み込めなくなったのを解消するため。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

`@learn-react/builder` の Vite 設定を修正した。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

#1994 で Vite が `v6.0.9` にアップデートされたことにより、 `server.cors` の初期値が `false` となった。これにより stories を `iframe` 内で読み込めなくなった。以前の初期値である `true` を明示的に指定することで stories が正常に表示されるようになった。

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
