### PR TITLE
feat(try): learn React Konva

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,7 +15,8 @@
     "dbaeumer.vscode-eslint",
     "stylelint.vscode-stylelint",
     "DavidAnson.vscode-markdownlint",
-    // スペルミス検出
+
+    // Utility
     "streetsidesoftware.code-spell-checker"
   ],
 

--- a/cspell.json
+++ b/cspell.json
@@ -81,6 +81,7 @@
     "nonwords",
     "stylelintrc",
     "formkit",
-    "nodenv"
+    "nodenv",
+    "konva"
   ]
 }

--- a/packages/try/package.json
+++ b/packages/try/package.json
@@ -8,7 +8,10 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@learn-react/core": "workspace:1.0.0",
+    "konva": "9.3.20",
     "qs": "6.14.0",
+    "react-konva": "19.0.3",
+    "react-konva-utils": "1.1.0",
     "swr": "2.3.3"
   },
   "devDependencies": {

--- a/packages/try/src/ReactKonva/AccessKonvaNodes.story.tsx
+++ b/packages/try/src/ReactKonva/AccessKonvaNodes.story.tsx
@@ -1,0 +1,33 @@
+import type Konva from 'konva';
+import { type KonvaEventObject } from 'konva/lib/Node';
+import { type FC, useEffect, useRef } from 'react';
+import { Circle, Layer, Rect, Stage, Text } from 'react-konva';
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Access_Konva_Nodes.html Access Konva Nodes}
+ */
+export const Story: FC = () => {
+  const rectRef = useRef<Konva.Rect>(null);
+
+  const handleCircleClick = (event: KonvaEventObject<MouseEvent>) => {
+    console.info(event);
+  };
+
+  useEffect(() => {
+    console.info(rectRef.current);
+  }, []);
+
+  return (
+    <>
+      <h2>Getting Started</h2>
+
+      <Stage width={600} height={720}>
+        <Layer>
+          <Text text="Try to drag shapes" fontSize={16} />
+          <Rect ref={rectRef} draggable x={20} y={50} width={100} height={100} fill="red" shadowBlur={10} />
+          <Circle draggable x={200} y={100} radius={50} fill="green" onClick={handleCircleClick} />
+        </Layer>
+      </Stage>
+    </>
+  );
+};

--- a/packages/try/src/ReactKonva/CanvasExport.story.tsx
+++ b/packages/try/src/ReactKonva/CanvasExport.story.tsx
@@ -1,0 +1,53 @@
+import type Konva from 'konva';
+import { type FC, useRef } from 'react';
+import { Layer, Rect, Stage } from 'react-konva';
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Canvas_Export.html Canvas Export}
+ */
+export const Story: FC = () => {
+  const stageRef = useRef<Konva.Stage>(null);
+
+  const stageWidth = 600;
+  const stageHeight = 720;
+
+  const handleExport = () => {
+    const uri = stageRef.current?.toDataURL();
+
+    if (!uri) {
+      return;
+    }
+
+    console.info({ uri });
+
+    downloadUri(uri, 'stage.png');
+  };
+
+  return (
+    <>
+      <h2>How to export a canvas into an image from react-konva?</h2>
+
+      <button onClick={handleExport}>Export</button>
+
+      <Stage ref={stageRef} width={stageWidth} height={stageHeight}>
+        <Layer>
+          <Rect x={0} y={0} width={80} height={80} fill="red" />
+          <Rect x={stageWidth - 80} y={0} width={80} height={80} fill="red" />
+          <Rect x={stageWidth - 80} y={stageHeight - 80} width={80} height={80} fill="red" />
+          <Rect x={0} y={stageHeight - 80} width={80} height={80} fill="red" />
+        </Layer>
+      </Stage>
+    </>
+  );
+};
+
+function downloadUri(uri: string, filename: string) {
+  const link = document.createElement('a');
+
+  link.download = filename;
+  link.href = uri;
+
+  document.body.append(link);
+  link.click();
+  link.remove();
+}

--- a/packages/try/src/ReactKonva/CanvasPortal.story.tsx
+++ b/packages/try/src/ReactKonva/CanvasPortal.story.tsx
@@ -1,6 +1,7 @@
 import { useState, type FC } from 'react';
 import { Circle, Layer, Line, Rect, Stage, Text } from 'react-konva';
 import { Portal } from 'react-konva-utils';
+import { serializePoints } from './utils/point';
 
 /**
  * @see {@link https://konvajs.org/docs/react/Canvas_Portal.html Canvas Portal}
@@ -44,7 +45,11 @@ export const Story: FC = () => {
             draggable
             x={30}
             y={200}
-            points={[0, 0, 100, 0, 100, 100]}
+            points={serializePoints([
+              { x: 0, y: 0 },
+              { x: 100, y: 0 },
+              { x: 100, y: 100 },
+            ])}
             tension={0.5}
             stroke="black"
             fillLinearGradientStartPoint={{ x: -50, y: -50 }}

--- a/packages/try/src/ReactKonva/CanvasPortal.story.tsx
+++ b/packages/try/src/ReactKonva/CanvasPortal.story.tsx
@@ -1,0 +1,60 @@
+import { useState, type FC } from 'react';
+import { Circle, Layer, Line, Rect, Stage, Text } from 'react-konva';
+import { Portal } from 'react-konva-utils';
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Canvas_Portal.html Canvas Portal}
+ */
+export const Story: FC = () => {
+  const [dragging, setDragging] = useState(false);
+
+  const handleDragStart = () => {
+    setDragging(true);
+  };
+
+  const handleDragEnd = () => {
+    setDragging(false);
+  };
+
+  return (
+    <>
+      <h2>How to use portals in react-konva?</h2>
+
+      <Stage width={600} height={720}>
+        <Layer>
+          <Text text="Try to drag the rectangle. It should be on top while drag." fontSize={16} />
+
+          <Portal selector=".top-layer" enabled={dragging}>
+            <Rect
+              draggable
+              x={20}
+              y={50}
+              width={150}
+              height={150}
+              fill="red"
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+            />
+          </Portal>
+
+          <Circle x={200} y={100} radius={50} fill="green" />
+
+          <Line
+            closed
+            draggable
+            x={30}
+            y={200}
+            points={[0, 0, 100, 0, 100, 100]}
+            tension={0.5}
+            stroke="black"
+            fillLinearGradientStartPoint={{ x: -50, y: -50 }}
+            fillLinearGradientEndPoint={{ x: 50, y: 50 }}
+            fillLinearGradientColorStops={[0, 'red', 1, 'yellow']}
+          />
+        </Layer>
+
+        <Layer name="top-layer" />
+      </Stage>
+    </>
+  );
+};

--- a/packages/try/src/ReactKonva/CustomShape.story.tsx
+++ b/packages/try/src/ReactKonva/CustomShape.story.tsx
@@ -1,0 +1,33 @@
+import type Konva from 'konva';
+import { type FC } from 'react';
+import { Layer, Shape, Stage } from 'react-konva';
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Custom_Shape.html Custom Shape}
+ */
+export const Story: FC = () => {
+  const shapeFunction = (context: Konva.Context, shape: Konva.Shape) => {
+    const width = shape.width();
+    const height = shape.height();
+
+    context.beginPath();
+    context.moveTo(0, 0);
+    context.lineTo(width - 40, height - 90);
+    context.quadraticCurveTo(width - 110, height - 70, width, height);
+    context.closePath();
+
+    context.fillStrokeShape(shape);
+  };
+
+  return (
+    <>
+      <h2>How to draw custom shapes with React?</h2>
+
+      <Stage width={600} height={720}>
+        <Layer>
+          <Shape width={260} height={170} fill="#00D2FF" stroke="black" strokeWidth={4} sceneFunc={shapeFunction} />
+        </Layer>
+      </Stage>
+    </>
+  );
+};

--- a/packages/try/src/ReactKonva/DragAndDrop.story.tsx
+++ b/packages/try/src/ReactKonva/DragAndDrop.story.tsx
@@ -1,0 +1,54 @@
+import { type KonvaEventObject } from 'konva/lib/Node';
+import { type FC, useState } from 'react';
+import { Layer, Stage, Text } from 'react-konva';
+
+type Position = {
+  x: number;
+  y: number;
+};
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Drag_And_Drop.html Drag and Drop}
+ */
+export const Story: FC = () => {
+  const [dragging, setDragging] = useState(false);
+
+  const [position, setPosition] = useState<Position>({
+    x: 50,
+    y: 50,
+  });
+
+  const handleDragStart = () => {
+    setDragging(true);
+  };
+
+  const handleDragEnd = (event: KonvaEventObject<MouseEvent>) => {
+    setDragging(false);
+
+    setPosition({
+      x: event.target.x(),
+      y: event.target.y(),
+    });
+  };
+
+  return (
+    <>
+      <h2>Drag and drop canvas shapes</h2>
+
+      <Stage width={600} height={720}>
+        <Layer>
+          <Text
+            draggable
+            text="Draggable Text"
+            x={position.x}
+            y={position.y}
+            fontSize={dragging ? 20 : 16}
+            fill={dragging ? 'red' : 'black'}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          />
+        </Layer>
+      </Stage>
+    </>
+  );
+};

--- a/packages/try/src/ReactKonva/Events.story.tsx
+++ b/packages/try/src/ReactKonva/Events.story.tsx
@@ -1,0 +1,83 @@
+import type Konva from 'konva';
+import { type FC, useState } from 'react';
+import { Layer, Stage, Star, Text } from 'react-konva';
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Events.html Events}
+ */
+export const Story: FC = () => {
+  const [stars, setStars] = useState(() => generateShapes());
+
+  const handleDragStart = (event: Konva.KonvaEventObject<DragEvent>) => {
+    setStars((previous) =>
+      previous.map((star) => ({
+        ...star,
+        dragging: star.id === event.target.id(),
+      })),
+    );
+  };
+
+  const handleDragEnd = () => {
+    setStars((previous) =>
+      previous.map((star) => ({
+        ...star,
+        dragging: false,
+      })),
+    );
+  };
+
+  return (
+    <>
+      <h2>How to listen to an event on a canvas shape with React and Konva?</h2>
+
+      <Stage width={600} height={720}>
+        <Layer>
+          <Text text="Try to drag a star" fontSize={16} />
+
+          {stars.map((star) => (
+            <Star
+              key={star.id}
+              draggable
+              id={star.id}
+              x={star.x}
+              y={star.y}
+              numPoints={5}
+              innerRadius={20}
+              outerRadius={40}
+              fill="#89b717"
+              opacity={0.8}
+              rotation={star.rotation}
+              shadowColor="black"
+              shadowBlur={10}
+              shadowOpacity={0.6}
+              shadowOffsetX={star.dragging ? 10 : 5}
+              shadowOffsetY={star.dragging ? 10 : 5}
+              scaleX={star.dragging ? 1.2 : 1}
+              scaleY={star.dragging ? 1.2 : 1}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+            />
+          ))}
+        </Layer>
+      </Stage>
+    </>
+  );
+};
+
+type ShapeProp = {
+  id: string;
+  x: number;
+  y: number;
+  rotation: number;
+  dragging: boolean;
+};
+
+function generateShapes(): ShapeProp[] {
+  return [...Array(10).keys()].map((i) => ({
+    id: i.toString(),
+    x: Math.random() * 600,
+    y: Math.random() * 720,
+    rotation: Math.random() * 180,
+    dragging: false,
+  }));
+}

--- a/packages/try/src/ReactKonva/Filters.story.tsx
+++ b/packages/try/src/ReactKonva/Filters.story.tsx
@@ -1,0 +1,78 @@
+import Konva from 'konva';
+import { use, useEffect, useRef, useState, type ComponentProps, type FC } from 'react';
+import { Image, Layer, Rect, Stage } from 'react-konva';
+import { loadImage } from './utils/image';
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Filters.html Filters}
+ */
+export const Story: FC = () => {
+  const imagePromise = loadImage('https://konvajs.org/assets/lion.png');
+
+  return (
+    <>
+      <h2>How to apply canvas filters with React and Konva?</h2>
+
+      <Stage width={600} height={720}>
+        <Layer>
+          <FilteredRect draggable />
+          <FilteredImage imagePromise={imagePromise} />
+        </Layer>
+      </Stage>
+    </>
+  );
+};
+
+type FilteredRectProps = Pick<ComponentProps<typeof Rect>, 'draggable'>;
+
+const FilteredRect: FC<FilteredRectProps> = ({ draggable }) => {
+  const [color, setColor] = useState('green');
+
+  const rectRef = useRef<Konva.Rect>(null);
+
+  useEffect(() => {
+    if (rectRef.current) {
+      rectRef.current.cache();
+    }
+  });
+
+  const handleClick = () => {
+    setColor(Konva.Util.getRandomColor());
+    // recache shape when we updated it
+    rectRef.current?.cache();
+  };
+
+  return (
+    <Rect
+      ref={rectRef}
+      draggable={draggable}
+      filters={[Konva.Filters.Noise]}
+      noise={1}
+      x={200}
+      y={10}
+      width={150}
+      height={150}
+      fill={color}
+      shadowBlur={10}
+      onClick={handleClick}
+    />
+  );
+};
+
+type FilteredImageProps = {
+  imagePromise: Promise<HTMLImageElement>;
+};
+
+const FilteredImage: FC<FilteredImageProps> = ({ imagePromise }) => {
+  const image = use(imagePromise);
+
+  const imageRef = useRef<Konva.Image>(null);
+
+  useEffect(() => {
+    if (imageRef.current) {
+      imageRef.current.cache();
+    }
+  });
+
+  return <Image ref={imageRef} x={10} y={10} image={image} filters={[Konva.Filters.Blur]} blurRadius={100} />;
+};

--- a/packages/try/src/ReactKonva/FreeDrawing.story.tsx
+++ b/packages/try/src/ReactKonva/FreeDrawing.story.tsx
@@ -1,6 +1,7 @@
 import { type KonvaEventObject } from 'konva/lib/Node';
 import { useRef, useState, type ChangeEvent, type FC } from 'react';
 import { Layer, Line, Stage, Text } from 'react-konva';
+import { serializePoints, type Point } from './utils/point';
 
 /**
  * @see {@link https://konvajs.org/docs/react/Free_Drawing.html Free Drawing}
@@ -23,7 +24,7 @@ export const Story: FC = () => {
 
     drawingRef.current = true;
 
-    setLines((previous) => [...previous, { tool, points: [position.x, position.y] }]);
+    setLines((previous) => [...previous, { tool, points: [position] }]);
   };
 
   const handleMouseMove = (event: KonvaEventObject<MouseEvent | TouchEvent>) => {
@@ -38,7 +39,7 @@ export const Story: FC = () => {
     const lastLine = lines.at(-1);
     if (!lastLine) return;
 
-    lastLine.points = [...lastLine.points, position.x, position.y];
+    lastLine.points = [...lastLine.points, position];
 
     lines.splice(-1, 1, lastLine);
 
@@ -77,7 +78,7 @@ export const Story: FC = () => {
           {lines.map((line, i) => (
             <Line
               key={i}
-              points={line.points}
+              points={serializePoints(line.points)}
               stroke="#df4b26"
               strokeWidth={5}
               tension={0.5}
@@ -98,5 +99,5 @@ type Tool = (typeof Tool)[number];
 
 type Line = {
   tool: Tool;
-  points: number[];
+  points: Point[];
 };

--- a/packages/try/src/ReactKonva/FreeDrawing.story.tsx
+++ b/packages/try/src/ReactKonva/FreeDrawing.story.tsx
@@ -1,0 +1,102 @@
+import { type KonvaEventObject } from 'konva/lib/Node';
+import { useRef, useState, type ChangeEvent, type FC } from 'react';
+import { Layer, Line, Stage, Text } from 'react-konva';
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Free_Drawing.html Free Drawing}
+ */
+export const Story: FC = () => {
+  const [tool, setTool] = useState<Tool>('pen');
+
+  const [lines, setLines] = useState<Line[]>([]);
+
+  const drawingRef = useRef(false);
+
+  const handleChangeTool = (event: ChangeEvent<HTMLSelectElement>) => {
+    setTool(event.target.value as Tool);
+  };
+
+  const handleMouseDown = (event: KonvaEventObject<MouseEvent | TouchEvent>) => {
+    const position = event.target.getStage()?.getPointerPosition();
+
+    if (!position) return;
+
+    drawingRef.current = true;
+
+    setLines((previous) => [...previous, { tool, points: [position.x, position.y] }]);
+  };
+
+  const handleMouseMove = (event: KonvaEventObject<MouseEvent | TouchEvent>) => {
+    if (!drawingRef.current) return;
+
+    const stage = event.target.getStage();
+    if (!stage) return;
+
+    const position = stage.getPointerPosition();
+    if (!position) return;
+
+    const lastLine = lines.at(-1);
+    if (!lastLine) return;
+
+    lastLine.points = [...lastLine.points, position.x, position.y];
+
+    lines.splice(-1, 1, lastLine);
+
+    setLines([...lines]);
+  };
+
+  const handleMouseUp = () => {
+    drawingRef.current = false;
+  };
+
+  return (
+    <>
+      <h2>How to implement free drawing on canvas with React?</h2>
+
+      <select value={tool} onChange={handleChangeTool}>
+        {Tool.map((tool) => (
+          <option key={tool} value={tool}>
+            {tool}
+          </option>
+        ))}
+      </select>
+
+      <Stage
+        width={600}
+        height={720}
+        onMouseDown={handleMouseDown}
+        onMousemove={handleMouseMove}
+        onMouseup={handleMouseUp}
+        onTouchStart={handleMouseDown}
+        onTouchMove={handleMouseMove}
+        onTouchEnd={handleMouseUp}
+      >
+        <Layer>
+          <Text text="Just start drawing" fontSize={16} />
+
+          {lines.map((line, i) => (
+            <Line
+              key={i}
+              points={line.points}
+              stroke="#df4b26"
+              strokeWidth={5}
+              tension={0.5}
+              lineCap="round"
+              lineJoin="round"
+              globalCompositeOperation={line.tool === 'eraser' ? 'destination-out' : 'source-over'}
+            />
+          ))}
+        </Layer>
+      </Stage>
+    </>
+  );
+};
+
+const Tool = ['pen', 'eraser'] as const;
+
+type Tool = (typeof Tool)[number];
+
+type Line = {
+  tool: Tool;
+  points: number[];
+};

--- a/packages/try/src/ReactKonva/Images.story.tsx
+++ b/packages/try/src/ReactKonva/Images.story.tsx
@@ -1,0 +1,38 @@
+import { type FC, Suspense, use } from 'react';
+import { Image, Layer, Stage } from 'react-konva';
+import { loadImage } from './utils/image';
+
+/**
+ * @remarks
+ * 公式チュートリアルでは画像を読み込むために `use-image` というカスタムフックを使用していますが、
+ * ここでは React の組み込みフックである `use` を使って画像を読み込む方法を紹介します。
+ *
+ * @see {@link https://konvajs.org/docs/react/Images.html Images}
+ */
+export const Story: FC = () => {
+  const imagePromise = loadImage('https://konvajs.org/assets/lion.png');
+
+  return (
+    <>
+      <h2>How to draw images on canvas with React?</h2>
+
+      <Suspense fallback={<div>Loading...</div>}>
+        <Stage width={600} height={720}>
+          <Layer>
+            <MyImage imagePromise={imagePromise} />
+          </Layer>
+        </Stage>
+      </Suspense>
+    </>
+  );
+};
+
+type InternalProps = {
+  imagePromise: Promise<HTMLImageElement>;
+};
+
+const MyImage: FC<InternalProps> = ({ imagePromise }) => {
+  const image = use(imagePromise);
+
+  return <Image image={image} x={100} y={100} width={200} height={200} />;
+};

--- a/packages/try/src/ReactKonva/README.md
+++ b/packages/try/src/ReactKonva/README.md
@@ -1,0 +1,5 @@
+# React Konva
+
+> React Konva の使い方を学ぶ。
+
+[Getting started with React and Canvas via Konva | Konva - JavaScript Canvas 2d Library](https://konvajs.org/docs/react/index.html)

--- a/packages/try/src/ReactKonva/Shapes.story.tsx
+++ b/packages/try/src/ReactKonva/Shapes.story.tsx
@@ -1,0 +1,33 @@
+import { type FC } from 'react';
+import { Circle, Layer, Line, Rect, Stage, Text } from 'react-konva';
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Shapes.html Shapes}
+ */
+export const Story: FC = () => (
+  <>
+    <h2>Drawing canvas shapes with React</h2>
+
+    <Stage width={600} height={720}>
+      <Layer>
+        <Text text="Some text on canvas" fontSize={16} />
+
+        <Rect x={20} y={50} width={100} height={100} fill="red" shadowBlur={10} />
+
+        <Circle x={200} y={100} radius={50} fill="green" />
+
+        <Line
+          closed
+          x={20}
+          y={200}
+          points={[0, 0, 100, 0, 100, 100]}
+          tension={0.5}
+          stroke="black"
+          fillLinearGradientStartPoint={{ x: -50, y: -50 }}
+          fillLinearGradientEndPoint={{ x: 50, y: 50 }}
+          fillLinearGradientColorStops={[0, 'red', 1, 'yellow']}
+        />
+      </Layer>
+    </Stage>
+  </>
+);

--- a/packages/try/src/ReactKonva/Shapes.story.tsx
+++ b/packages/try/src/ReactKonva/Shapes.story.tsx
@@ -1,5 +1,6 @@
 import { type FC } from 'react';
 import { Circle, Layer, Line, Rect, Stage, Text } from 'react-konva';
+import { serializePoints } from './utils/point';
 
 /**
  * @see {@link https://konvajs.org/docs/react/Shapes.html Shapes}
@@ -20,7 +21,11 @@ export const Story: FC = () => (
           closed
           x={20}
           y={200}
-          points={[0, 0, 100, 0, 100, 100]}
+          points={serializePoints([
+            { x: 0, y: 0 },
+            { x: 100, y: 0 },
+            { x: 100, y: 100 },
+          ])}
           tension={0.5}
           stroke="black"
           fillLinearGradientStartPoint={{ x: -50, y: -50 }}

--- a/packages/try/src/ReactKonva/SimpleAnimations.story.tsx
+++ b/packages/try/src/ReactKonva/SimpleAnimations.story.tsx
@@ -1,0 +1,40 @@
+import type Konva from 'konva';
+import { type FC, useRef } from 'react';
+import { Layer, Rect, Stage } from 'react-konva';
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Simple_Animations.html Simple Animations}
+ */
+export const Story: FC = () => {
+  const rectRef = useRef<Konva.Rect>(null);
+
+  const handleDrag = () => {
+    if (!rectRef.current) return;
+
+    rectRef.current.to({
+      scaleX: Math.random() + 0.8,
+      scaleY: Math.random() + 0.8,
+      duration: 0.2,
+    });
+  };
+
+  return (
+    <>
+      <h2>How to apply canvas animations with React and Konva?</h2>
+
+      <Stage width={600} height={720}>
+        <Layer>
+          <Rect
+            ref={rectRef}
+            draggable
+            width={50}
+            height={50}
+            fill="green"
+            onDragStart={handleDrag}
+            onDragEnd={handleDrag}
+          />
+        </Layer>
+      </Stage>
+    </>
+  );
+};

--- a/packages/try/src/ReactKonva/Transformer.story.tsx
+++ b/packages/try/src/ReactKonva/Transformer.story.tsx
@@ -1,0 +1,155 @@
+import type Konva from 'konva';
+import { type KonvaEventObject } from 'konva/lib/Node';
+import { type Box } from 'konva/lib/shapes/Transformer';
+import { type ComponentProps, type FC, useEffect, useRef, useState } from 'react';
+import { Layer, Rect, Stage, Transformer } from 'react-konva';
+
+type ShapeProps = Pick<ComponentProps<typeof Rect>, 'x' | 'y' | 'width' | 'height' | 'fill' | 'id'>;
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Transformer.html Transformer}
+ */
+export const Story: FC = () => {
+  const [rectangles, setRectangles] = useState<ShapeProps[]>([
+    {
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 100,
+      fill: 'red',
+      id: 'rect1',
+    },
+    {
+      x: 150,
+      y: 150,
+      width: 100,
+      height: 100,
+      fill: 'green',
+      id: 'rect2',
+    },
+  ]);
+
+  const [selectedId, setSelectedId] = useState<ShapeProps['id'] | null>(null);
+
+  const checkDeselect = (event: KonvaEventObject<MouseEvent | TouchEvent>) => {
+    const clickedOnEmpty = event.target === event.target.getStage();
+
+    if (clickedOnEmpty) {
+      setSelectedId(null);
+    }
+  };
+
+  const handleChange = (newAttributes: ShapeProps, index: number) => {
+    const rects = [...rectangles];
+    rects[index] = newAttributes;
+    setRectangles(rects);
+  };
+
+  return (
+    <>
+      <h2>How to resize and rotate canvas shapes with React and Konva?</h2>
+
+      <Stage width={600} height={720} onMouseDown={checkDeselect} onTouchStart={checkDeselect}>
+        <Layer>
+          {rectangles.map((rectangle, index) => (
+            <Rectangle
+              key={rectangle.id}
+              shape={rectangle}
+              selected={rectangle.id === selectedId}
+              onSelect={() => {
+                setSelectedId(rectangle.id);
+              }}
+              onChange={(newAttributes) => {
+                handleChange(newAttributes, index);
+              }}
+            />
+          ))}
+        </Layer>
+      </Stage>
+    </>
+  );
+};
+
+type RectangleProps = {
+  shape: ShapeProps;
+  selected: boolean;
+  onSelect: (event: KonvaEventObject<MouseEvent>) => void;
+  onChange: (newAttributes: ShapeProps) => void;
+};
+
+const Rectangle: FC<RectangleProps> = ({ shape, selected, onSelect, onChange }) => {
+  const shapeRef = useRef<Konva.Rect>(null);
+
+  const transformerRef = useRef<Konva.Transformer>(null);
+
+  const handleSelect = (event: KonvaEventObject<MouseEvent>) => {
+    onSelect(event);
+  };
+
+  const handleDragEnd = (event: KonvaEventObject<MouseEvent>) => {
+    onChange({
+      ...shape,
+      x: event.target.x(),
+      y: event.target.y(),
+    });
+  };
+
+  const handleTransformEnd = () => {
+    if (!shapeRef.current) return;
+
+    // transformer is changing scale of the node
+    // and NOT its width or height
+    // but in the store we have only width and height
+    // to match the data better we will reset scale on transform end
+    const node = shapeRef.current;
+    const scaleX = node.scaleX();
+    const scaleY = node.scaleY();
+
+    // we will reset it back
+    node.scaleX(1);
+    node.scaleY(1);
+
+    onChange({
+      ...shape,
+      x: node.x(),
+      y: node.y(),
+      // set minimal value
+      width: Math.max(5, node.width() * scaleX),
+      height: Math.max(5, node.height() * scaleY),
+    });
+  };
+
+  const boundBox = (oldBox: Box, newBox: Box) => {
+    if (Math.abs(newBox.width) < 5 || Math.abs(newBox.height) < 5) {
+      return oldBox;
+    }
+
+    return newBox;
+  };
+
+  useEffect(() => {
+    if (!selected || !transformerRef.current || !shapeRef.current) return;
+    transformerRef.current.nodes([shapeRef.current]);
+  }, [selected]);
+
+  return (
+    <>
+      <Rect
+        ref={shapeRef}
+        draggable
+        id={shape.id}
+        x={shape.x}
+        y={shape.y}
+        width={shape.width}
+        height={shape.height}
+        fill={shape.fill}
+        onClick={handleSelect}
+        onTap={handleSelect}
+        onDragEnd={handleDragEnd}
+        onTransformEnd={handleTransformEnd}
+      />
+
+      {selected ? <Transformer ref={transformerRef} boundBoxFunc={boundBox} /> : null}
+    </>
+  );
+};

--- a/packages/try/src/ReactKonva/UndoRedo.story.tsx
+++ b/packages/try/src/ReactKonva/UndoRedo.story.tsx
@@ -1,0 +1,75 @@
+import { type KonvaEventObject } from 'konva/lib/Node';
+import { type FC, useRef, useState } from 'react';
+import { Layer, Rect, Stage } from 'react-konva';
+
+type Position = {
+  x: number;
+  y: number;
+};
+
+/**
+ * @see {@link https://konvajs.org/docs/react/Undo-Redo.html Undo/Redo}
+ */
+export const Story: FC = () => {
+  const initialPosition: Position = {
+    x: 20,
+    y: 20,
+  };
+
+  const [position, setPosition] = useState<Position>(initialPosition);
+
+  const history = useRef<Position[]>([initialPosition]);
+
+  const historyStep = useRef(0);
+
+  const handleUndo = () => {
+    if (historyStep.current === 0) return;
+
+    historyStep.current -= 1;
+    const previous = history.current[historyStep.current];
+
+    setPosition(previous);
+  };
+
+  const handleRedo = () => {
+    if (historyStep.current >= history.current.length - 1) return;
+
+    historyStep.current += 1;
+    const next = history.current[historyStep.current];
+
+    setPosition(next);
+  };
+
+  const handleDragEnd = (event: KonvaEventObject<DragEvent>) => {
+    // Remove all states after current step
+    history.current = history.current.slice(0, historyStep.current + 1);
+
+    const position: Position = {
+      x: event.target.x(),
+      y: event.target.y(),
+    };
+
+    // Push the new state
+    history.current = [...history.current, position];
+    historyStep.current += 1;
+    setPosition(position);
+  };
+
+  return (
+    <>
+      <h2>How to implement undo/redo on canvas with React?</h2>
+      <button disabled={historyStep.current === 0} onClick={handleUndo}>
+        Undo
+      </button>
+      <button disabled={historyStep.current === history.current.length - 1} onClick={handleRedo}>
+        Redo
+      </button>
+
+      <Stage width={600} height={720}>
+        <Layer>
+          <Rect draggable x={position.x} y={position.y} width={50} height={50} fill="red" onDragEnd={handleDragEnd} />
+        </Layer>
+      </Stage>
+    </>
+  );
+};

--- a/packages/try/src/ReactKonva/ZIndex.story.tsx
+++ b/packages/try/src/ReactKonva/ZIndex.story.tsx
@@ -1,0 +1,65 @@
+import Konva from 'konva';
+import { type KonvaEventObject } from 'konva/lib/Node';
+import { useState, type ComponentProps, type FC } from 'react';
+import { Circle, Layer, Stage } from 'react-konva';
+
+type Item = Pick<ComponentProps<typeof Circle>, 'x' | 'y' | 'id' | 'fill'>;
+
+export const Story: FC = () => {
+  const [items, setItems] = useState<Item[]>(() =>
+    [...Array(10).keys()].map((index) => ({
+      x: Math.random() * 600,
+      y: Math.random() * 720,
+      id: `circle${index}`,
+      fill: Konva.Util.getRandomColor(),
+    })),
+  );
+
+  const handleDragStart = (event: KonvaEventObject<MouseEvent | TouchEvent>) => {
+    const id = event.target.name();
+
+    setItems((previousItems) => {
+      const filteredItems = previousItems.filter((item) => item.id !== id);
+      const draggedItem = previousItems.find((item) => item.id === id);
+
+      return draggedItem ? [...filteredItems, draggedItem] : filteredItems;
+    });
+  };
+
+  const handleDragEnd = (event: KonvaEventObject<MouseEvent | TouchEvent>) => {
+    const id = event.target.name();
+    const x = event.target.x();
+    const y = event.target.y();
+
+    setItems((previousItems) => {
+      const filteredItems = previousItems.filter((item) => item.id !== id);
+      const draggedItem = previousItems.find((item) => item.id === id);
+
+      return draggedItem ? [...filteredItems, { ...draggedItem, x, y }] : filteredItems;
+    });
+  };
+
+  return (
+    <>
+      <h2>How to change the zIndex of nodes with React?</h2>
+
+      <Stage width={600} height={720}>
+        <Layer>
+          {items.map((item) => (
+            <Circle
+              key={item.id}
+              draggable
+              name={item.id}
+              x={item.x}
+              y={item.y}
+              fill={item.fill}
+              radius={50}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+            />
+          ))}
+        </Layer>
+      </Stage>
+    </>
+  );
+};

--- a/packages/try/src/ReactKonva/utils/image.ts
+++ b/packages/try/src/ReactKonva/utils/image.ts
@@ -1,0 +1,24 @@
+/**
+ * 指定された URL から画像を非同期に読み込みます。
+ *
+ * @param src - 読み込む画像の URL。
+ *
+ * @returns 読み込まれた画像を含む Promise。
+ *
+ * @example
+ * ```typescript
+ * const image = await loadImage('https://example.com/image.png');
+ * console.log(image.width, image.height);
+ * ```
+ */
+export function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve) => {
+    const image = new Image();
+
+    image.src = src;
+    image.addEventListener('load', () => {
+      console.info('Image loaded');
+      resolve(image);
+    });
+  });
+}

--- a/packages/try/src/ReactKonva/utils/point.ts
+++ b/packages/try/src/ReactKonva/utils/point.ts
@@ -1,0 +1,46 @@
+export type Point = {
+  x: number;
+  y: number;
+};
+
+/**
+ * Converts an array of points to a flat array of numbers.
+ *
+ * @param points - An array of points, where each point is an object with x and y properties.
+ *
+ * @returns - A flat array of numbers representing the x and y coordinates of each point.
+ *
+ * @example
+ * ```typescript
+ * const points = [{ x: 1, y: 2 }, { x: 3, y: 4 }];
+ * const serialized = serializePoints(points);
+ * console.log(serialized); // [1, 2, 3, 4]
+ * ```
+ */
+export function serializePoints(points: Point[]): number[] {
+  return points.flatMap((point) => [point.x, point.y]);
+}
+
+/**
+ * Converts a flat array of numbers to an array of points.
+ *
+ * @param points - A flat array of numbers representing the x and y coordinates of each point.
+ *
+ * @returns - An array of points, where each point is an object with x and y properties.
+ *
+ * @example
+ * ```typescript
+ * const serialized = [1, 2, 3, 4];
+ * const points = deserializePoints(serialized);
+ * console.log(points); // [{ x: 1, y: 2 }, { x: 3, y: 4 }]
+ * ```
+ */
+export function deserializePoints(points: number[]): Point[] {
+  const result: Point[] = [];
+
+  for (let i = 0; i < points.length; i += 2) {
+    result.push({ x: points[i], y: points[i + 1] });
+  }
+
+  return result;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,9 +574,18 @@ importers:
       '@learn-react/core':
         specifier: workspace:1.0.0
         version: link:../core
+      konva:
+        specifier: 9.3.20
+        version: 9.3.20
       qs:
         specifier: 6.14.0
         version: 6.14.0
+      react-konva:
+        specifier: 19.0.3
+        version: 19.0.3(@types/react@19.0.12)(konva@9.3.20)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-konva-utils:
+        specifier: 1.1.0
+        version: 1.1.0(konva@9.3.20)(react-dom@19.1.0(react@19.1.0))(react-konva@19.0.3(@types/react@19.0.12)(konva@9.3.20)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       swr:
         specifier: 2.3.3
         version: 2.3.3(react@19.1.0)
@@ -1754,6 +1763,11 @@ packages:
     resolution: {integrity: sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==}
     peerDependencies:
       '@types/react': ^19.0.0
+
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
 
   '@types/react@19.0.12':
     resolution: {integrity: sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==}
@@ -3457,6 +3471,11 @@ packages:
     resolution: {integrity: sha512-x4WH0BWmrMmg4oHHl+duwubhrvczGlyuGAZu3nvrf0UXOfPu8IhZObFEr7DE/iv01YgVZrsOiRcqw2srkKEDIA==}
     engines: {node: '>= 0.4'}
 
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -3564,6 +3583,9 @@ packages:
 
   known-css-properties@0.35.0:
     resolution: {integrity: sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==}
+
+  konva@9.3.20:
+    resolution: {integrity: sha512-7XPD/YtgfzC8b1c7z0hhY5TF1IO/pBYNa29zMTA2PeBaqI0n5YplUeo4JRuRcljeAF8lWtW65jePZZF7064c8w==}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -4252,6 +4274,27 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-konva-utils@1.1.0:
+    resolution: {integrity: sha512-3ylRN4eUeYU553tmY2Hgi69efrlUBjE8MLXXAQT+rLDBCPW4CwlvJFUCgPQoSEZmaJKTH/gvZz0Y4f8tUfV0rw==}
+    peerDependencies:
+      konva: ^8.3.5 || ^9.0.0
+      react: ^18.2.0 || ^19.0.0
+      react-dom: ^18.2.0 || ^19.0.0
+      react-konva: ^18.2.10 || ^19.0.1
+
+  react-konva@19.0.3:
+    resolution: {integrity: sha512-MxaGCwKCo9DiGBPfsJKU1JShZ9YRsCjrJNF/KVyyzBB7UjrRtY7s46hH1Obr70y4trYZzFuqmW3ljB/mO0dAfA==}
+    peerDependencies:
+      konva: ^8.0.1 || ^7.2.5 || ^9.0.0
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
+  react-reconciler@0.31.0:
+    resolution: {integrity: sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.0.0
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -4404,6 +4447,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.25.0:
+    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -4865,6 +4911,12 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-image@1.1.1:
+    resolution: {integrity: sha512-n4YO2k8AJG/BcDtxmBx8Aa+47kxY5m335dJiCQA5tTeVU4XdhrhqR6wT0WISRXwdMEOv5CSjqekDZkEMiiWaYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   use-sync-external-store@1.4.0:
     resolution: {integrity: sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==}
@@ -6303,6 +6355,10 @@ snapshots:
   '@types/qs@6.9.18': {}
 
   '@types/react-dom@19.0.4(@types/react@19.0.12)':
+    dependencies:
+      '@types/react': 19.0.12
+
+  '@types/react-reconciler@0.28.9(@types/react@19.0.12)':
     dependencies:
       '@types/react': 19.0.12
 
@@ -8305,6 +8361,13 @@ snapshots:
       reflect.getprototypeof: 1.0.9
       set-function-name: 2.0.2
 
+  its-fine@2.0.0(@types/react@19.0.12)(react@19.1.0):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.0.12)
+      react: 19.1.0
+    transitivePeerDependencies:
+      - '@types/react'
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -8410,6 +8473,8 @@ snapshots:
   kind-of@6.0.3: {}
 
   known-css-properties@0.35.0: {}
+
+  konva@9.3.20: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -9024,6 +9089,31 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-konva-utils@1.1.0(konva@9.3.20)(react-dom@19.1.0(react@19.1.0))(react-konva@19.0.3(@types/react@19.0.12)(konva@9.3.20)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0):
+    dependencies:
+      konva: 9.3.20
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-konva: 19.0.3(@types/react@19.0.12)(konva@9.3.20)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      use-image: 1.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+
+  react-konva@19.0.3(@types/react@19.0.12)(konva@9.3.20)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.0.12)
+      its-fine: 2.0.0(@types/react@19.0.12)(react@19.1.0)
+      konva: 9.3.20
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-reconciler: 0.31.0(react@19.1.0)
+      scheduler: 0.25.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  react-reconciler@0.31.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.25.0
+
   react-refresh@0.14.2: {}
 
   react-router-dom@7.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
@@ -9192,6 +9282,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.25.0: {}
 
   scheduler@0.26.0: {}
 
@@ -9751,6 +9843,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-image@1.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   use-sync-external-store@1.4.0(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

兼業先で React Konva を用いた UI を実装することになったため。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

`@learn-react/try` ワークスペースで [Getting started with React and Canvas via Konva | Konva - JavaScript Canvas 2d Library](https://konvajs.org/docs/react/index.html) を写経した。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

チュートリアルでは画像ファイルを読み込む方法として [`use-image`](https://www.npmjs.com/package/use-image) が採用されているが、依存ライブラリが増えるのは避けたい。そこで Promise と [`use`](https://react.dev/reference/react/use) を組み合わせて実現した。

`Line` コンポーネントの `points` プロパティは `[x, y, x, y,...]` という `x` , `y` 座標値を number 型の一元配列として表現したものだが、これが分かりにくい。そこで `{ x: number; y: number; }` というオブジェクトから `[x, y, x, y,...]` への相互変換を実現する utility 関数を実装した。

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

- [Getting started with React and Canvas via Konva | Konva - JavaScript Canvas 2d Library](https://konvajs.org/docs/react/index.html)

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
