### PR TITLE
fix: iframe sandbox

### DIFF
--- a/apps/catalog/src/pages/StoryPage/index.tsx
+++ b/apps/catalog/src/pages/StoryPage/index.tsx
@@ -85,7 +85,7 @@ const Presentation = () => {
                 src={`/preview.html?storyId=${storyId}`}
                 title={[...storyKeys].reverse().join(' | ')}
                 style={deviceSizeValue}
-                // sandbox="allow-scripts allow-same-origin allow-popups-to-escape-sandbox allow-forms"
+                sandbox="allow-scripts allow-same-origin allow-popups-to-escape-sandbox allow-forms"
               />
             </div>
 

--- a/apps/catalog/src/pages/StoryPage/index.tsx
+++ b/apps/catalog/src/pages/StoryPage/index.tsx
@@ -77,6 +77,7 @@ const Presentation = () => {
             orientation={layoutConfig !== Layout.Zen ? layoutConfig : Layout.Horizontal}
           >
             <div className={cx(styleViewport, Object.values(deviceSizeValue).every(nonNull) && styleViewportChanged)}>
+              {/* eslint-disable-next-line react/iframe-missing-sandbox */}
               <iframe
                 // story page 切替時に前回の preview が一瞬だが残ってしまうのを回避するために
                 // 強制的に再マウントしてゼロからレンダリングさせている。
@@ -84,7 +85,7 @@ const Presentation = () => {
                 src={`/preview.html?storyId=${storyId}`}
                 title={[...storyKeys].reverse().join(' | ')}
                 style={deviceSizeValue}
-                sandbox="allow-scripts allow-popups-to-escape-sandbox allow-forms"
+                // sandbox="allow-scripts allow-same-origin allow-popups-to-escape-sandbox allow-forms"
               />
             </div>
 


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

AWS 上で `@learn-react/catalog` の各 story が `iframe` 内に表示されないのを解消するため。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

AWS 上でも各 story を `iframe` 内に表示されるよう修正した。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

ややリスキーだが `iframe` の `sandbox` を無効化することにした。

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

- [\<iframe\>: The Inline Frame element - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox)

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
