### PR TITLE
feat(core): implement `Modal` component with dialog element

### DIFF
--- a/cspell.config.js
+++ b/cspell.config.js
@@ -47,7 +47,7 @@ export default defineConfig({
     // CSS-related terms
     ...['palt'],
     // DOM-related terms
-    ...['pointerupoutside'],
+    ...['closedby', 'pointerupoutside'],
     // Other terms
     ...['codegen', 'qiita', 'wakamsha'],
   ],

--- a/packages/core/src/components/utils/Modal2/index.story.tsx
+++ b/packages/core/src/components/utils/Modal2/index.story.tsx
@@ -1,0 +1,155 @@
+import { css } from '@emotion/css';
+import { type FC, useState } from 'react';
+import { Modal } from '.';
+import { FontSize, LineHeight } from '../../../constants/Style';
+import { cssVar, gutter } from '../../../helpers/Style';
+import { Card } from '../../surfaces/Card';
+
+export const Story: FC = () => {
+  const [lightDismiss, setLightDismiss] = useState(false);
+
+  const [visible1, setVisible1] = useState(false);
+
+  const [visible2, setVisible2] = useState(false);
+
+  const [visible3, setVisible3] = useState(false);
+
+  const handleToggle1 = () => {
+    console.info('Toggling modal 1 visibility');
+    setVisible1((state) => !state);
+  };
+
+  const handleToggle2 = () => {
+    setVisible2((state) => !state);
+  };
+
+  const handleToggle3 = () => {
+    setVisible3((state) => !state);
+  };
+
+  const handleLightDismiss = () => {
+    setLightDismiss((state) => !state);
+  };
+
+  return (
+    <>
+      <label>
+        <input type="checkbox" checked={lightDismiss} onChange={handleLightDismiss} />
+        Light dismiss
+      </label>
+
+      <h2>Normal content</h2>
+      <button onClick={handleToggle1}>Open</button>
+
+      <h2>Very long content</h2>
+      <button onClick={handleToggle2}>Open</button>
+
+      <h2>Liquid Content</h2>
+      <button onClick={handleToggle3}>Open</button>
+
+      <pre>
+        <code>
+          {JSON.stringify(
+            {
+              lightDismiss,
+              visible1,
+              visible2,
+              visible3,
+            },
+            null,
+            2,
+          )}
+        </code>
+      </pre>
+
+      <Modal open={visible1} lightDismiss={lightDismiss} onClose={handleToggle1}>
+        <article className={styleCard}>
+          <h1 className={styleHeading}>Hello!!</h1>
+          <footer className={styleFooter}>
+            <input type="text" />
+            <button onClick={handleToggle1}>Close</button>
+          </footer>
+        </article>
+      </Modal>
+
+      <Modal open={visible2} lightDismiss={lightDismiss} onClose={handleToggle2}>
+        <article className={styleCard}>
+          <h1 className={styleHeading}>ポラーノの広場</h1>
+          <div className={styleBody}>
+            <LongContent />
+          </div>
+          <footer className={styleFooter}>
+            <input type="text" />
+            <button onClick={handleToggle2}>Close</button>
+          </footer>
+        </article>
+      </Modal>
+
+      <Modal open={visible3} lightDismiss={lightDismiss} onClose={handleToggle3}>
+        <Card maxWidth={400} maxHeight={`calc(100dvh - ${gutter(20)})`}>
+          <Card.Header>
+            <h1>ポラーノの広場</h1>
+          </Card.Header>
+          <Card.Body>
+            <LongContent />
+          </Card.Body>
+          <Card.Footer>
+            <input type="text" />
+            <button onClick={handleToggle3}>Close</button>
+          </Card.Footer>
+        </Card>
+      </Modal>
+    </>
+  );
+};
+
+const LongContent = () => (
+  <>
+    <p>そのころわたくしは、モリーオ市の博物局に勤めて居りました</p>
+    <p>
+      十八等官でしたから役所のなかでも、ずうっと下の方でしたし俸給もほんのわずかでしたが、受持ちが標本の採集や整理で生れ付き好きなことでしたから、わたくしは毎日ずいぶん愉快にはたらきました。殊にそのころ、モリーオ市では競馬場を植物園に拵こしらえ直すというので、その景色のいいまわりにアカシヤを植え込んだ広い地面が、切符売場や信号所の建物のついたまま、わたくしどもの役所の方へまわって来たものですから、わたくしはすぐ宿直という名前で月賦で買った小さな蓄音器と二十枚ばかりのレコードをもって、その番小屋にひとり住むことになりました。わたくしはそこの馬を置く場所に板で小さなしきいをつけて一疋の山羊を飼いました。毎朝その乳をしぼってつめたいパンをひたしてたべ、それから黒い革のかばんへすこしの書類や雑誌を入れ、靴もきれいにみがき、並木のポプラの影法師を大股にわたって市の役所へ出て行くのでした。
+    </p>
+    <p>
+      あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら、うつくしい森で飾られたモリーオ市、郊外のぎらぎらひかる草の波。またそのなかでいっしょになったたくさんのひとたち、ファゼーロとロザーロ、羊飼のミーロや、顔の赤いこどもたち、地主のテーモ、山猫博士のボーガント・デストゥパーゴなど、いまこの暗い巨きな石の建物のなかで考えていると、みんなむかし風のなつかしい青い幻燈のように思われます。では、わたくしはいつかの小さなみだしをつけながら、しずかにあの年のイーハトーヴォの五月から十月までを書きつけましょう。
+    </p>
+    <p>
+      五月のしまいの日曜でした。わたくしは賑やかな市の教会の鐘の音で眼をさましました。もう日はよほど登って、まわりはみんなきらきらしていました。時計を見るとちょうど六時でした。わたくしはすぐチョッキだけ着て山羊を見に行きました。すると小屋のなかはしんとして藁が凹んでいるだけで、あのみじかい角も白い髯も見えませんでした。
+    </p>
+    <p>「あんまりいい天気なもんだから大将ひとりででかけたな。」</p>
+    <p>
+      わたくしは半分わらうように半分つぶやくようにしながら、向うの信号所からいつも放して遊ばせる輪道の内側の野原、ポプラの中から顔をだしている市はずれの白い教会の塔までぐるっと見まわしました。けれどもどこにもあの白い頭もせなかも見えていませんでした。うまやを一まわりしてみましたがやっぱりどこにも居ませんでした。
+    </p>
+  </>
+);
+
+const styleCard = css`
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+  overflow: hidden;
+  font-size: ${FontSize.Regular};
+  background-color: ${cssVar('TexturePaper')};
+  box-shadow: ${cssVar('ShadowDialog')};
+
+  > :not(:first-child) {
+    border-top: 1px solid ${cssVar('LineLight')};
+  }
+`;
+
+const styleHeading = css`
+  flex: 0 0 auto;
+  padding: ${gutter(4)};
+`;
+
+const styleBody = css`
+  flex: 1 1 100%;
+  padding: ${gutter(4)};
+  overflow: auto;
+  font-size: ${FontSize.Large};
+  line-height: ${LineHeight.Medium};
+`;
+
+const styleFooter = css`
+  flex: 0 0 auto;
+  padding: ${gutter(4)};
+`;

--- a/packages/core/src/components/utils/Modal2/index.tsx
+++ b/packages/core/src/components/utils/Modal2/index.tsx
@@ -1,0 +1,114 @@
+import { css } from '@emotion/css';
+import { type FC, type ReactNode, useEffect, useRef } from 'react';
+import { Color, Duration, Easing } from '../../../constants/Style';
+import { hex2rgba } from '../../../helpers/Style';
+
+type Props = {
+  children: ReactNode;
+  /**
+   * Whether the modal is open or closed.
+   */
+  open: boolean;
+  /**
+   * Whether the modal can be dismissed by clicking outside of it or pressing the Escape key.
+   * If true, clicking outside the modal or pressing Escape will close it.
+   */
+  lightDismiss?: boolean;
+  /**
+   * Callback function to be called when the modal is closed.
+   */
+  onClose: () => void;
+};
+
+/**
+ * Modal component that uses the HTML dialog element.
+ */
+export const Modal: FC<Props> = ({ children, open, lightDismiss = false, onClose }) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const closedBy = lightDismiss ? 'any' : 'none';
+
+  useEffect(() => {
+    if (!dialogRef.current) return;
+
+    if (open) {
+      dialogRef.current.showModal();
+    } else {
+      dialogRef.current.close();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!lightDismiss || !dialogRef.current) return;
+
+    const node = dialogRef.current;
+
+    const handleCancel = (event: Event) => {
+      if (event.target !== node) return;
+      onClose();
+    };
+
+    node.addEventListener('cancel', handleCancel);
+
+    return () => {
+      node.removeEventListener('cancel', handleCancel);
+    };
+  }, [lightDismiss, onClose]);
+
+  return (
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    // eslint-disable-next-line react/no-unknown-property
+    <dialog ref={dialogRef} className={styleBase} closedby={closedBy}>
+      {children}
+    </dialog>
+  );
+};
+
+const styleBase = css`
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  animation: fade-out ${Duration.Enter} ${Easing.Enter};
+
+  &::backdrop {
+    background-color: ${hex2rgba(Color.TextureBackdrop.light, 0.8)};
+    backdrop-filter: blur(8px);
+
+    @media (prefers-color-scheme: dark) {
+      background-color: ${hex2rgba(Color.TextureBackdrop.dark, 0.8)};
+    }
+  }
+
+  &[open] {
+    animation: fade-in ${Duration.Enter} ${Easing.Enter};
+  }
+
+  &[open]::backdrop {
+    animation: backdrop-fade-in ${Duration.Enter} ${Easing.Enter};
+  }
+
+  @keyframes fade-in {
+    0% {
+      display: none;
+      opacity: 0;
+      transform: scale(0.9);
+    }
+
+    100% {
+      display: block;
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  @keyframes backdrop-fade-in {
+    0% {
+      opacity: 0;
+    }
+
+    100% {
+      opacity: 1;
+    }
+  }
+`;


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

`dialog` 要素に対する知識を深めるため。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

HTML の標準要素である `dialog` をベースにして `Modal` コンポーネントを実装した。これにより、適切なアクセシビリティを少ないコード量で実現できる。

- Light Dismiss のサポート
  - `esc` キー押下でモーダルを閉じることができる
  - コンテンツ領域外（背景のオーバーレイ）クリックでモーダルを閉じることができる
- モーダルコンテンツにフォーカスが集中する（フォーカストラップ）

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

Light Dismiss を実現するために `<dialog>` 要素の `closedby` 属性を活用している。2025年7月時点では Chrome および Edge でしかサポートされていないが、これによりコンテンツ領域外のクリックもしくは `esc` キー押下でモーダルを閉じることが可能となる。

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

- [\<dialog\>: ダイアログ要素 - HTML | MDN](https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/dialog)

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

https://github.com/user-attachments/assets/9c6ca25e-344d-4ec1-9adf-b1761695359d


