### PR TITLE
refactor(core): Scroll Lock

### DIFF
--- a/packages/core/src/components/utils/Modal/index.tsx
+++ b/packages/core/src/components/utils/Modal/index.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import { useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { Color, Duration, Easing, ZIndex } from '../../../constants/Style';
-import { isVisibleScrollbarOf, scrollbarSize } from '../../../helpers/Browser';
 import { gutter, hex2rgba } from '../../../helpers/Style';
 import { useFocusTrap } from '../../../hooks/useFocusTrap';
 
@@ -27,17 +26,12 @@ export const Modal = ({ children, visible, onClickOutside }: Props) => {
 
   useEffect(() => {
     // モーダル表示時にページ全体をスクロールロックする。
-    if (visible && isVisibleScrollbarOf()) {
-      document.documentElement.style.overflow = 'hidden';
-      document.documentElement.style.paddingRight = `${scrollbarSize()}px`;
-    } else {
-      document.documentElement.style.overflow = '';
-      document.documentElement.style.paddingRight = '';
-    }
+    document.documentElement.style.scrollbarGutter = visible ? 'stable' : '';
+    document.documentElement.style.overflow = visible ? 'hidden' : '';
 
     return () => {
+      document.documentElement.style.scrollbarGutter = '';
       document.documentElement.style.overflow = '';
-      document.documentElement.style.paddingRight = '';
     };
   }, [visible]);
 

--- a/packages/core/src/components/utils/Modal/index.tsx
+++ b/packages/core/src/components/utils/Modal/index.tsx
@@ -26,12 +26,12 @@ export const Modal = ({ children, visible, onClickOutside }: Props) => {
 
   useEffect(() => {
     // モーダル表示時にページ全体をスクロールロックする。
-    document.documentElement.style.scrollbarGutter = visible ? 'stable' : '';
     document.documentElement.style.overflow = visible ? 'hidden' : '';
+    document.documentElement.style.scrollbarGutter = visible ? 'stable' : '';
 
     return () => {
-      document.documentElement.style.scrollbarGutter = '';
       document.documentElement.style.overflow = '';
+      document.documentElement.style.scrollbarGutter = '';
     };
   }, [visible]);
 

--- a/packages/core/src/components/utils/Modal2/index.story.tsx
+++ b/packages/core/src/components/utils/Modal2/index.story.tsx
@@ -62,7 +62,7 @@ export const Story: FC = () => {
         </code>
       </pre>
 
-      <Modal open={visible1} lightDismiss={lightDismiss} onClose={handleToggle1}>
+      <Modal open={visible1} onLightDismiss={lightDismiss ? handleToggle1 : undefined}>
         <article className={styleCard}>
           <h1 className={styleHeading}>Hello!!</h1>
           <footer className={styleFooter}>
@@ -72,7 +72,7 @@ export const Story: FC = () => {
         </article>
       </Modal>
 
-      <Modal open={visible2} lightDismiss={lightDismiss} onClose={handleToggle2}>
+      <Modal open={visible2} onLightDismiss={lightDismiss ? handleToggle2 : undefined}>
         <article className={styleCard}>
           <h1 className={styleHeading}>ポラーノの広場</h1>
           <div className={styleBody}>
@@ -85,7 +85,7 @@ export const Story: FC = () => {
         </article>
       </Modal>
 
-      <Modal open={visible3} lightDismiss={lightDismiss} onClose={handleToggle3}>
+      <Modal open={visible3} onLightDismiss={lightDismiss ? handleToggle3 : undefined}>
         <Card maxWidth={400} maxHeight={`calc(100dvh - ${gutter(20)})`}>
           <Card.Header>
             <h1>ポラーノの広場</h1>

--- a/packages/core/src/components/utils/Modal2/index.story.tsx
+++ b/packages/core/src/components/utils/Modal2/index.story.tsx
@@ -62,7 +62,7 @@ export const Story: FC = () => {
         </code>
       </pre>
 
-      <Modal open={visible1} onLightDismiss={lightDismiss ? handleToggle1 : undefined}>
+      <Modal open={visible1} lightDismiss={lightDismiss} onClose={handleToggle1}>
         <article className={styleCard}>
           <h1 className={styleHeading}>Hello!!</h1>
           <footer className={styleFooter}>
@@ -72,7 +72,7 @@ export const Story: FC = () => {
         </article>
       </Modal>
 
-      <Modal open={visible2} onLightDismiss={lightDismiss ? handleToggle2 : undefined}>
+      <Modal open={visible2} lightDismiss={lightDismiss} onClose={handleToggle2}>
         <article className={styleCard}>
           <h1 className={styleHeading}>ポラーノの広場</h1>
           <div className={styleBody}>
@@ -85,7 +85,7 @@ export const Story: FC = () => {
         </article>
       </Modal>
 
-      <Modal open={visible3} onLightDismiss={lightDismiss ? handleToggle3 : undefined}>
+      <Modal open={visible3} lightDismiss={lightDismiss} onClose={handleToggle3}>
         <Card maxWidth={400} maxHeight={`calc(100dvh - ${gutter(20)})`}>
           <Card.Header>
             <h1>ポラーノの広場</h1>

--- a/packages/core/src/components/utils/Modal2/index.tsx
+++ b/packages/core/src/components/utils/Modal2/index.tsx
@@ -10,18 +10,23 @@ type Props = {
    */
   open: boolean;
   /**
-   * Callback function to be called when the modal is dismissed by clicking outside of it or pressing the Escape key.
+   * Whether the modal can be dismissed by clicking outside of it or pressing the Escape key.
+   * If true, clicking outside the modal or pressing Escape will close it.
    */
-  onLightDismiss?: () => void;
+  lightDismiss?: boolean;
+  /**
+   * Callback function to be called when the modal is closed.
+   */
+  onClose: () => void;
 };
 
 /**
  * Modal component that uses the HTML dialog element.
  */
-export const Modal: FC<Props> = ({ children, open, onLightDismiss }) => {
+export const Modal: FC<Props> = ({ children, open, lightDismiss = false, onClose }) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
-  const closedBy = onLightDismiss ? 'any' : 'none';
+  const closedBy = lightDismiss ? 'any' : 'none';
 
   // dialog 要素の表示・非表示を制御する
   useEffect(() => {
@@ -47,14 +52,13 @@ export const Modal: FC<Props> = ({ children, open, onLightDismiss }) => {
 
   // Light dismiss 有効時の背景領域クリックや Escape キーでの閉じる処理を設定する
   useEffect(() => {
-    if (!dialogRef.current) return;
+    if (!lightDismiss || !dialogRef.current) return;
 
     const node = dialogRef.current;
 
     const handleCancel = (event: Event) => {
       if (event.target !== node) return;
-      event.preventDefault();
-      onLightDismiss?.();
+      onClose();
     };
 
     node.addEventListener('cancel', handleCancel);
@@ -62,7 +66,7 @@ export const Modal: FC<Props> = ({ children, open, onLightDismiss }) => {
     return () => {
       node.removeEventListener('cancel', handleCancel);
     };
-  }, [onLightDismiss]);
+  }, [lightDismiss, onClose]);
 
   return (
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/core/src/components/utils/Modal2/index.tsx
+++ b/packages/core/src/components/utils/Modal2/index.tsx
@@ -86,6 +86,7 @@ const styleBase = css`
 
   &::backdrop {
     background-color: ${hex2rgba(Color.TextureBackdrop.light, 0.8)};
+    backdrop-filter: blur(8px);
 
     @media (prefers-color-scheme: dark) {
       background-color: ${hex2rgba(Color.TextureBackdrop.dark, 0.8)};

--- a/packages/core/src/components/utils/Modal2/index.tsx
+++ b/packages/core/src/components/utils/Modal2/index.tsx
@@ -10,24 +10,20 @@ type Props = {
    */
   open: boolean;
   /**
-   * Whether the modal can be dismissed by clicking outside of it or pressing the Escape key.
-   * If true, clicking outside the modal or pressing Escape will close it.
+   * Callback function to be called when the modal is dismissed by clicking outside of it or pressing the Escape key.
    */
-  lightDismiss?: boolean;
-  /**
-   * Callback function to be called when the modal is closed.
-   */
-  onClose: () => void;
+  onLightDismiss?: () => void;
 };
 
 /**
  * Modal component that uses the HTML dialog element.
  */
-export const Modal: FC<Props> = ({ children, open, lightDismiss = false, onClose }) => {
+export const Modal: FC<Props> = ({ children, open, onLightDismiss }) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
-  const closedBy = lightDismiss ? 'any' : 'none';
+  const closedBy = onLightDismiss ? 'any' : 'none';
 
+  // dialog 要素の表示・非表示を制御する
   useEffect(() => {
     if (!dialogRef.current) return;
 
@@ -38,14 +34,27 @@ export const Modal: FC<Props> = ({ children, open, lightDismiss = false, onClose
     }
   }, [open]);
 
+  // モーダル表示時にページ全体をスクロールロックする
   useEffect(() => {
-    if (!lightDismiss || !dialogRef.current) return;
+    document.documentElement.style.scrollbarGutter = open ? 'stable' : '';
+    document.documentElement.style.overflow = open ? 'hidden' : '';
+
+    return () => {
+      document.documentElement.style.scrollbarGutter = '';
+      document.documentElement.style.overflow = '';
+    };
+  }, [open]);
+
+  // Light dismiss 有効時の背景領域クリックや Escape キーでの閉じる処理を設定する
+  useEffect(() => {
+    if (!dialogRef.current) return;
 
     const node = dialogRef.current;
 
     const handleCancel = (event: Event) => {
       if (event.target !== node) return;
-      onClose();
+      event.preventDefault();
+      onLightDismiss?.();
     };
 
     node.addEventListener('cancel', handleCancel);
@@ -53,7 +62,7 @@ export const Modal: FC<Props> = ({ children, open, lightDismiss = false, onClose
     return () => {
       node.removeEventListener('cancel', handleCancel);
     };
-  }, [lightDismiss, onClose]);
+  }, [onLightDismiss]);
 
   return (
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -73,7 +82,6 @@ const styleBase = css`
 
   &::backdrop {
     background-color: ${hex2rgba(Color.TextureBackdrop.light, 0.8)};
-    backdrop-filter: blur(8px);
 
     @media (prefers-color-scheme: dark) {
       background-color: ${hex2rgba(Color.TextureBackdrop.dark, 0.8)};

--- a/packages/core/src/components/utils/Modal2/index.tsx
+++ b/packages/core/src/components/utils/Modal2/index.tsx
@@ -41,12 +41,12 @@ export const Modal: FC<Props> = ({ children, open, lightDismiss = false, onClose
 
   // モーダル表示時にページ全体をスクロールロックする
   useEffect(() => {
-    document.documentElement.style.scrollbarGutter = open ? 'stable' : '';
     document.documentElement.style.overflow = open ? 'hidden' : '';
+    document.documentElement.style.scrollbarGutter = open ? 'stable' : '';
 
     return () => {
-      document.documentElement.style.scrollbarGutter = '';
       document.documentElement.style.overflow = '';
+      document.documentElement.style.scrollbarGutter = '';
     };
   }, [open]);
 

--- a/packages/core/src/components/utils/Popover/index.tsx
+++ b/packages/core/src/components/utils/Popover/index.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { useEffect, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { Duration, ZIndex } from '../../../constants/Style';
-import { isVisibleScrollbarOf, scrollbarSize } from '../../../helpers/Browser';
+import { isVisibleScrollbarOf } from '../../../helpers/Browser';
 import { useFocusTrap } from '../../../hooks/useFocusTrap';
 
 type Position = 'top' | 'right' | 'bottom' | 'left';
@@ -75,16 +75,16 @@ export const Popover = ({
   useEffect(() => {
     // ポップオーバー表示時にページ全体のスクロールを無効化する。
     if (visible && isVisibleScrollbarOf()) {
+      document.documentElement.style.scrollbarGutter = 'stable';
       document.documentElement.style.overflow = 'hidden';
-      document.documentElement.style.paddingRight = `${scrollbarSize()}px`;
     } else {
+      document.documentElement.style.scrollbarGutter = '';
       document.documentElement.style.overflow = '';
-      document.documentElement.style.paddingRight = '';
     }
 
     return () => {
+      document.documentElement.style.scrollbarGutter = '';
       document.documentElement.style.overflow = '';
-      document.documentElement.style.paddingRight = '';
     };
   }, [visible]);
 

--- a/packages/core/src/components/utils/Popover/index.tsx
+++ b/packages/core/src/components/utils/Popover/index.tsx
@@ -75,16 +75,16 @@ export const Popover = ({
   useEffect(() => {
     // ポップオーバー表示時にページ全体のスクロールを無効化する。
     if (visible && isVisibleScrollbarOf()) {
-      document.documentElement.style.scrollbarGutter = 'stable';
       document.documentElement.style.overflow = 'hidden';
+      document.documentElement.style.scrollbarGutter = 'stable';
     } else {
-      document.documentElement.style.scrollbarGutter = '';
       document.documentElement.style.overflow = '';
+      document.documentElement.style.scrollbarGutter = '';
     }
 
     return () => {
-      document.documentElement.style.scrollbarGutter = '';
       document.documentElement.style.overflow = '';
+      document.documentElement.style.scrollbarGutter = '';
     };
   }, [visible]);
 

--- a/packages/core/src/helpers/Browser.ts
+++ b/packages/core/src/helpers/Browser.ts
@@ -1,5 +1,8 @@
 /**
  * web ブラウザの scrollbar のサイズ ( px ) を取得します。
+ *
+ * @deprecated
+ * 現在この関数はどこからも参照されていません。将来破棄される可能性があります。
  */
 export function scrollbarSize(): number {
   const outer = document.createElement('div');


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

モーダルやポップオーバー表示時にウィンドウ全体のスクロールをロックする処理を簡易化できることが判明したため。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

ウィンドウ全体のスクロールをロックする際にページコンテンツのレイアウトシフトを防止する処理をリファクタリングした。これにより、今まで以上に web 標準に準拠した設計・実装を実現できるようになった。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

これまではレイアウトシフトを防止するためにスクロールバーのサイズ分だけ padding-right を動的に設定する処理を自前で実装していたが、 `scrollbar-gutter` 属性が使えるようになったことでその計算処理が不要になった。

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
