### PR TITLE
fix(core): enable closing modal by `esc` key on FireFox and Safari

### DIFF
--- a/packages/core/src/components/utils/Modal2/index.story.tsx
+++ b/packages/core/src/components/utils/Modal2/index.story.tsx
@@ -15,7 +15,6 @@ export const Story: FC = () => {
   const [visible3, setVisible3] = useState(false);
 
   const handleToggle1 = () => {
-    console.info('Toggling modal 1 visibility');
     setVisible1((state) => !state);
   };
 
@@ -62,7 +61,7 @@ export const Story: FC = () => {
         </code>
       </pre>
 
-      <Modal open={visible1} lightDismiss={lightDismiss} onClose={handleToggle1}>
+      <Modal open={visible1} onLightDismiss={lightDismiss ? handleToggle1 : undefined}>
         <article className={styleCard}>
           <h1 className={styleHeading}>Hello!!</h1>
           <footer className={styleFooter}>
@@ -72,7 +71,7 @@ export const Story: FC = () => {
         </article>
       </Modal>
 
-      <Modal open={visible2} lightDismiss={lightDismiss} onClose={handleToggle2}>
+      <Modal open={visible2} onLightDismiss={lightDismiss ? handleToggle2 : undefined}>
         <article className={styleCard}>
           <h1 className={styleHeading}>ポラーノの広場</h1>
           <div className={styleBody}>
@@ -85,7 +84,7 @@ export const Story: FC = () => {
         </article>
       </Modal>
 
-      <Modal open={visible3} lightDismiss={lightDismiss} onClose={handleToggle3}>
+      <Modal open={visible3} onLightDismiss={lightDismiss ? handleToggle3 : undefined}>
         <Card maxWidth={400} maxHeight={`calc(100dvh - ${gutter(20)})`}>
           <Card.Header>
             <h1>ポラーノの広場</h1>

--- a/packages/core/src/components/utils/Modal2/index.tsx
+++ b/packages/core/src/components/utils/Modal2/index.tsx
@@ -10,23 +10,18 @@ type Props = {
    */
   open: boolean;
   /**
-   * Whether the modal can be dismissed by clicking outside of it or pressing the Escape key.
-   * If true, clicking outside the modal or pressing Escape will close it.
+   * Callback function to be called when the modal is dismissed by clicking outside of it or pressing the Escape key.
    */
-  lightDismiss?: boolean;
-  /**
-   * Callback function to be called when the modal is closed.
-   */
-  onClose: () => void;
+  onLightDismiss?: () => void;
 };
 
 /**
  * Modal component that uses the HTML dialog element.
  */
-export const Modal: FC<Props> = ({ children, open, lightDismiss = false, onClose }) => {
+export const Modal: FC<Props> = ({ children, open, onLightDismiss }) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
-  const closedBy = lightDismiss ? 'any' : 'none';
+  const closedBy = onLightDismiss ? 'any' : 'none';
 
   // dialog 要素の表示・非表示を制御する
   useEffect(() => {
@@ -52,13 +47,14 @@ export const Modal: FC<Props> = ({ children, open, lightDismiss = false, onClose
 
   // Light dismiss 有効時の背景領域クリックや Escape キーでの閉じる処理を設定する
   useEffect(() => {
-    if (!lightDismiss || !dialogRef.current) return;
+    if (!dialogRef.current) return;
 
     const node = dialogRef.current;
 
     const handleCancel = (event: Event) => {
       if (event.target !== node) return;
-      onClose();
+      event.preventDefault();
+      onLightDismiss?.();
     };
 
     node.addEventListener('cancel', handleCancel);
@@ -66,7 +62,7 @@ export const Modal: FC<Props> = ({ children, open, lightDismiss = false, onClose
     return () => {
       node.removeEventListener('cancel', handleCancel);
     };
-  }, [lightDismiss, onClose]);
+  }, [onLightDismiss]);
 
   return (
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

Firefox および Safari におけるアクセシビリティを向上させるため。

### 何を変更したのか

<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

Firefox および Safari でも `esc` キー押下で `Modal2` を閉じれるようにした。

### 技術的にはどこがポイントか

<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

Firefox および Safari は `<dialog>` 要素の `closedby` 属性をサポートしていないため、 `lightDismiss` プロパティの値および `onLightDismiss` コールバックの有無に関係なく `esc` キーで勝手に Modal を閉じてしまう。これにより `open` プロパティの値と整合性が取れないという不具合があった。

これを解消すべく、`esc` キーによって発火する `<dialog>` 要素の `cancel` イベントを強制的に停止するようにした（ `preventDefault` ）。これにより Modal を閉じる処理は `open` プロパティを `false` にトグルする処理に一元化され、整合性が担保されるようになった。

領域外クリックは相変わらず未サポートだが、将来 Firefox と Safari がサポートすれば自動的に動作するようになる（コード修正は不要）[^1]。

[^1]: Firefox は v141 からサポートする予定。https://caniuse.com/?search=closedby

### どこまで動作確認したか

<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- いろいろ書いてよい。完了の定義以外で確認したこと、追加したライブラリの使い方など -->

## :classical_building: 参考文献

<!--
- [example](http://example.com)
- [example](http://example.com)
 -->

## :construction: TODO リスト / 未完了タスク

<!--- 詳細はここに書かず、 Issue を立ててリンクを貼る　-->

## :camera_flash: スクリーンショットや Movie ( 画面遷移、導線変更など ) :movie_camera:

| Before                           | After                            |
| -------------------------------- | -------------------------------- |
| <!-- 改修前のスクショ or Gif --> | <!-- 改修後のスクショ of Gif --> |
